### PR TITLE
Telegram-account proxy fetching: robust multi-format parser, deep pagination, and local-only credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,12 @@ graphify-out/
 
 # Go
 mtproto-checker.exe
+
+# Telegram credentials / session — must NEVER be committed.
+# (Primary storage is the OS user-config dir, outside the repo; these patterns
+# are a safety net in case anyone points the session path into the tree.)
+session.json
+app.json
+*.session
+mtproto-checker
+MTProto-Checker

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"regexp"
@@ -175,6 +176,7 @@ func checkProxy(ctx context.Context, server string, port int, secret string, tim
 
 type FetchChannelsRequest struct {
 	Channels []string `json:"channels"`
+	Proxy    string   `json:"proxy,omitempty"`
 }
 
 type FetchChannelsResponse struct {
@@ -212,19 +214,44 @@ func normalizeChannel(raw string) string {
 	return s
 }
 
+// buildHTTPClient returns an http.Client that routes through the given proxy.
+// Supports http://, https://, socks5:// and socks5h:// proxy URLs (all handled
+// natively by net/http). A bare "host:port" is treated as http://host:port.
+// An empty proxyRaw falls back to the standard environment-proxy behaviour.
+func buildHTTPClient(proxyRaw string) (*http.Client, error) {
+	proxyRaw = strings.TrimSpace(proxyRaw)
+	transport := &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
+		MaxIdleConns:        20,
+		IdleConnTimeout:     30 * time.Second,
+		TLSHandshakeTimeout: 8 * time.Second,
+	}
+	if proxyRaw != "" {
+		if !strings.Contains(proxyRaw, "://") {
+			proxyRaw = "http://" + proxyRaw
+		}
+		proxyURL, err := url.Parse(proxyRaw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy URL: %v", err)
+		}
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}
+	return &http.Client{Transport: transport}, nil
+}
+
 // fetchChannelProxies downloads the public web preview of a channel and extracts proxy links.
-func fetchChannelProxies(ctx context.Context, channel string) ([]string, error) {
-	url := "https://t.me/s/" + channel
+func fetchChannelProxies(ctx context.Context, client *http.Client, channel string) ([]string, error) {
+	reqURL := "https://t.me/s/" + channel
 	ctx, cancel := context.WithTimeout(ctx, channelFetchTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +624,17 @@ func main() {
 			}
 		}
 
-		log.Printf("FETCH START %d channels", len(channels))
+		client, err := buildHTTPClient(req.Proxy)
+		if err != nil {
+			jsonResponse(w, http.StatusBadRequest, FetchChannelsResponse{Errors: []string{err.Error()}})
+			return
+		}
+
+		viaProxy := "direct"
+		if strings.TrimSpace(req.Proxy) != "" {
+			viaProxy = "via proxy"
+		}
+		log.Printf("FETCH START %d channels (%s)", len(channels), viaProxy)
 		start := time.Now()
 
 		type chResult struct {
@@ -611,7 +648,7 @@ func main() {
 			wg.Add(1)
 			go func(ch string) {
 				defer wg.Done()
-				links, err := fetchChannelProxies(r.Context(), ch)
+				links, err := fetchChannelProxies(r.Context(), client, ch)
 				resultsCh <- chResult{links: links, err: err, name: ch}
 			}(name)
 		}

--- a/main.go
+++ b/main.go
@@ -7,16 +7,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"html"
-	"io"
 	"io/fs"
 	"log"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
-	"regexp"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -174,26 +170,13 @@ func checkProxy(ctx context.Context, server string, port int, secret string, tim
 	return pingResult, nil
 }
 
-type FetchChannelsRequest struct {
-	Channels []string `json:"channels"`
-	Proxy    string   `json:"proxy,omitempty"`
-}
-
 type FetchChannelsResponse struct {
 	Links  []string `json:"links"`
 	Count  int      `json:"count"`
 	Errors []string `json:"errors,omitempty"`
 }
 
-const (
-	channelFetchTimeout = 12 * time.Second
-	maxChannels         = 30
-	channelBodyLimit    = 8 * 1024 * 1024
-)
-
-// proxyLinkRe matches both tg://proxy?... and https://t.me/proxy?... links.
-// Stops at characters that cannot appear inside an href in the page HTML.
-var proxyLinkRe = regexp.MustCompile(`(?:tg://proxy|https?://t\.me/proxy)\?[^\s"'<>\\]+`)
+const maxChannels = 30
 
 // normalizeChannel turns user input (URL, @name, plain name) into a bare channel username.
 func normalizeChannel(raw string) string {
@@ -212,79 +195,6 @@ func normalizeChannel(raw string) string {
 		s = s[:i]
 	}
 	return s
-}
-
-// buildHTTPClient returns an http.Client that routes through the given proxy.
-// Supports http://, https://, socks5:// and socks5h:// proxy URLs (all handled
-// natively by net/http). A bare "host:port" is treated as http://host:port.
-// An empty proxyRaw falls back to the standard environment-proxy behaviour.
-func buildHTTPClient(proxyRaw string) (*http.Client, error) {
-	proxyRaw = strings.TrimSpace(proxyRaw)
-	transport := &http.Transport{
-		Proxy:               http.ProxyFromEnvironment,
-		MaxIdleConns:        20,
-		IdleConnTimeout:     30 * time.Second,
-		TLSHandshakeTimeout: 8 * time.Second,
-	}
-	if proxyRaw != "" {
-		if !strings.Contains(proxyRaw, "://") {
-			proxyRaw = "http://" + proxyRaw
-		}
-		proxyURL, err := url.Parse(proxyRaw)
-		if err != nil {
-			return nil, fmt.Errorf("invalid proxy URL: %v", err)
-		}
-		transport.Proxy = http.ProxyURL(proxyURL)
-	}
-	return &http.Client{Transport: transport}, nil
-}
-
-// fetchChannelProxies downloads the public web preview of a channel and extracts proxy links.
-func fetchChannelProxies(ctx context.Context, client *http.Client, channel string) ([]string, error) {
-	reqURL := "https://t.me/s/" + channel
-	ctx, cancel := context.WithTimeout(ctx, channelFetchTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status %d", resp.StatusCode)
-	}
-
-	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, channelBodyLimit))
-	if err != nil {
-		return nil, err
-	}
-	body := string(bodyBytes)
-
-	// If the public web preview is missing, the channel is private, misspelled,
-	// or has previews disabled — report that instead of a silent empty result.
-	if !strings.Contains(body, "tgme_widget_message") {
-		return nil, fmt.Errorf("no public preview (private channel, wrong name, or previews disabled)")
-	}
-
-	matches := proxyLinkRe.FindAllString(body, -1)
-	links := make([]string, 0, len(matches))
-	seen := make(map[string]struct{}, len(matches))
-	for _, m := range matches {
-		link := html.UnescapeString(m)
-		if _, ok := seen[link]; ok {
-			continue
-		}
-		seen[link] = struct{}{}
-		links = append(links, link)
-	}
-	return links, nil
 }
 
 func jsonResponse(w http.ResponseWriter, status int, v interface{}) {
@@ -592,92 +502,192 @@ func main() {
 		sendEvent("done", map[string]int{"working": working, "total": total})
 	}))
 
-	mux.HandleFunc("/fetch-channels", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+	// ---- Telegram authenticated channel fetching ----
+
+	// Check whether a stored session is still valid/authorized (through a proxy).
+	mux.HandleFunc("/tg/status", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-
-		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
-
-		var req FetchChannelsRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			jsonResponse(w, http.StatusBadRequest, FetchChannelsResponse{})
+		var req struct {
+			Proxy ProxyCreds `json:"proxy"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "invalid request"})
 			return
 		}
-
-		// Normalize + dedupe channel names
-		seenCh := make(map[string]struct{})
-		var channels []string
-		for _, c := range req.Channels {
-			name := normalizeChannel(c)
-			if name == "" {
-				continue
-			}
-			if _, ok := seenCh[name]; ok {
-				continue
-			}
-			seenCh[name] = struct{}{}
-			channels = append(channels, name)
-			if len(channels) >= maxChannels {
-				break
-			}
-		}
-
-		client, err := buildHTTPClient(req.Proxy)
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		authorized, err := isAuthorized(ctx, req.Proxy)
 		if err != nil {
-			jsonResponse(w, http.StatusBadRequest, FetchChannelsResponse{Errors: []string{err.Error()}})
+			jsonResponse(w, http.StatusOK, map[string]any{"authorized": false, "error": err.Error()})
 			return
 		}
+		jsonResponse(w, http.StatusOK, map[string]any{"authorized": authorized})
+	}))
 
-		viaProxy := "direct"
-		if strings.TrimSpace(req.Proxy) != "" {
-			viaProxy = "via proxy"
+	// Start a phone-number login (sends the code). Optionally accepts a custom
+	// api_id/api_hash which is persisted locally (outside the repo) for reuse.
+	mux.HandleFunc("/tg/login/start", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
 		}
-		log.Printf("FETCH START %d channels (%s)", len(channels), viaProxy)
-		start := time.Now()
-
-		type chResult struct {
-			links []string
-			err   error
-			name  string
+		var req struct {
+			Proxy   ProxyCreds `json:"proxy"`
+			Phone   string     `json:"phone"`
+			AppID   int        `json:"app_id,omitempty"`
+			AppHash string     `json:"app_hash,omitempty"`
 		}
-		resultsCh := make(chan chResult, len(channels))
-		var wg sync.WaitGroup
-		for _, name := range channels {
-			wg.Add(1)
-			go func(ch string) {
-				defer wg.Done()
-				links, err := fetchChannelProxies(r.Context(), client, ch)
-				resultsCh <- chResult{links: links, err: err, name: ch}
-			}(name)
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "invalid request"})
+			return
 		}
-		wg.Wait()
-		close(resultsCh)
-
-		seenLink := make(map[string]struct{})
-		var allLinks []string
-		var errs []string
-		for res := range resultsCh {
-			if res.err != nil {
-				errs = append(errs, fmt.Sprintf("%s: %v", res.name, res.err))
-				continue
+		if strings.TrimSpace(req.Phone) == "" {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "phone is required"})
+			return
+		}
+		appID, appHash := loadAppCreds()
+		if req.AppID != 0 && strings.TrimSpace(req.AppHash) != "" {
+			appID, appHash = req.AppID, strings.TrimSpace(req.AppHash)
+			if err := saveAppCreds(appID, appHash); err != nil {
+				log.Printf("WARN: could not persist app creds: %v", err)
 			}
-			for _, l := range res.links {
-				if _, ok := seenLink[l]; ok {
-					continue
+		}
+		if err := loginMgr.start(req.Proxy, strings.TrimSpace(req.Phone), appID, appHash); err != nil {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+			return
+		}
+		jsonResponse(w, http.StatusOK, map[string]any{"ok": true})
+	}))
+
+	mux.HandleFunc("/tg/login/code", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Code string `json:"code"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "invalid request"})
+			return
+		}
+		if err := loginMgr.submitCode(strings.TrimSpace(req.Code)); err != nil {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+			return
+		}
+		jsonResponse(w, http.StatusOK, map[string]any{"ok": true})
+	}))
+
+	mux.HandleFunc("/tg/login/password", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Password string `json:"password"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "invalid request"})
+			return
+		}
+		if err := loginMgr.submitPassword(req.Password); err != nil {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+			return
+		}
+		jsonResponse(w, http.StatusOK, map[string]any{"ok": true})
+	}))
+
+	mux.HandleFunc("/tg/login/status", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		state, errMsg, phone, sitekey := loginMgr.snapshot()
+		jsonResponse(w, http.StatusOK, map[string]any{"state": state, "error": errMsg, "phone": phone, "sitekey": sitekey})
+	}))
+
+	// Submit a solved reCAPTCHA token to satisfy a send-code challenge.
+	mux.HandleFunc("/tg/login/captcha", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			Token string `json:"token"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "invalid request"})
+			return
+		}
+		if strings.TrimSpace(req.Token) == "" {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": "token is required"})
+			return
+		}
+		if err := loginMgr.submitCaptcha(strings.TrimSpace(req.Token)); err != nil {
+			jsonResponse(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+			return
+		}
+		jsonResponse(w, http.StatusOK, map[string]any{"ok": true})
+	}))
+
+	// Report whether a saved session/credentials exist so the UI can resume
+	// without forcing a fresh login. This only reads local files (no network),
+	// so it is fast and safe to call on page load.
+	mux.HandleFunc("/tg/me", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{"has_session": false, "has_app_creds": false}
+		if path, err := sessionFilePath(); err == nil {
+			if info, serr := os.Stat(path); serr == nil && info.Size() > 0 {
+				resp["has_session"] = true
+			}
+		}
+		// Surface custom api_id/api_hash saved by the user (not the public test
+		// fallback) so the advanced fields can be pre-filled.
+		if path, err := appConfigPath(); err == nil {
+			if data, rerr := os.ReadFile(path); rerr == nil {
+				var cfg tgAppConfig
+				if json.Unmarshal(data, &cfg) == nil && cfg.AppID != 0 && cfg.AppHash != "" {
+					resp["has_app_creds"] = true
+					resp["app_id"] = cfg.AppID
+					resp["app_hash"] = cfg.AppHash
 				}
-				seenLink[l] = struct{}{}
-				allLinks = append(allLinks, l)
 			}
 		}
+		jsonResponse(w, http.StatusOK, resp)
+	}))
 
-		log.Printf("FETCH DONE %d links from %d channels (%v)", len(allLinks), len(channels), time.Since(start))
-		jsonResponse(w, http.StatusOK, FetchChannelsResponse{
-			Links:  allLinks,
-			Count:  len(allLinks),
-			Errors: errs,
-		})
+	mux.HandleFunc("/tg/logout", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if err := logout(); err != nil {
+			jsonResponse(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+			return
+		}
+		jsonResponse(w, http.StatusOK, map[string]any{"ok": true})
+	}))
+
+	// Fetch proxy links from channels using the authenticated MTProto client
+	// (tunneled through a working MTProto proxy — no HTTP/SOCKS proxy needed).
+	mux.HandleFunc("/fetch-channels-tg", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+		var req FetchTGRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonResponse(w, http.StatusBadRequest, FetchChannelsResponse{Errors: []string{"invalid request"}})
+			return
+		}
+		log.Printf("FETCH-TG START %d channels via %s:%d", len(req.Channels), req.Proxy.Server, req.Proxy.Port)
+		start := time.Now()
+		resp, err := fetchChannelsViaTelegram(r.Context(), req)
+		if err != nil {
+			jsonResponse(w, http.StatusOK, FetchChannelsResponse{Errors: []string{err.Error()}})
+			return
+		}
+		log.Printf("FETCH-TG DONE %d links (%v)", resp.Count, time.Since(start))
+		jsonResponse(w, http.StatusOK, resp)
 	}))
 
 	embeddedFS, err := fs.Sub(publicFS, "public")

--- a/main.go
+++ b/main.go
@@ -234,15 +234,28 @@ func fetchChannelProxies(ctx context.Context, channel string) ([]string, error) 
 		return nil, fmt.Errorf("status %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, channelBodyLimit))
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, channelBodyLimit))
 	if err != nil {
 		return nil, err
 	}
+	body := string(bodyBytes)
 
-	matches := proxyLinkRe.FindAllString(string(body), -1)
+	// If the public web preview is missing, the channel is private, misspelled,
+	// or has previews disabled — report that instead of a silent empty result.
+	if !strings.Contains(body, "tgme_widget_message") {
+		return nil, fmt.Errorf("no public preview (private channel, wrong name, or previews disabled)")
+	}
+
+	matches := proxyLinkRe.FindAllString(body, -1)
 	links := make([]string, 0, len(matches))
+	seen := make(map[string]struct{}, len(matches))
 	for _, m := range matches {
-		links = append(links, html.UnescapeString(m))
+		link := html.UnescapeString(m)
+		if _, ok := seen[link]; ok {
+			continue
+		}
+		seen[link] = struct{}{}
+		links = append(links, link)
 	}
 	return links, nil
 }

--- a/main.go
+++ b/main.go
@@ -7,12 +7,15 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
+	"io"
 	"io/fs"
 	"log"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"regexp"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -168,6 +171,80 @@ func checkProxy(ctx context.Context, server string, port int, secret string, tim
 		return 0, err
 	}
 	return pingResult, nil
+}
+
+type FetchChannelsRequest struct {
+	Channels []string `json:"channels"`
+}
+
+type FetchChannelsResponse struct {
+	Links  []string `json:"links"`
+	Count  int      `json:"count"`
+	Errors []string `json:"errors,omitempty"`
+}
+
+const (
+	channelFetchTimeout = 12 * time.Second
+	maxChannels         = 30
+	channelBodyLimit    = 8 * 1024 * 1024
+)
+
+// proxyLinkRe matches both tg://proxy?... and https://t.me/proxy?... links.
+// Stops at characters that cannot appear inside an href in the page HTML.
+var proxyLinkRe = regexp.MustCompile(`(?:tg://proxy|https?://t\.me/proxy)\?[^\s"'<>\\]+`)
+
+// normalizeChannel turns user input (URL, @name, plain name) into a bare channel username.
+func normalizeChannel(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimPrefix(s, "t.me/")
+	s = strings.TrimPrefix(s, "telegram.me/")
+	s = strings.TrimPrefix(s, "s/") // t.me/s/<name>
+	s = strings.TrimPrefix(s, "@")
+	// Drop anything after the username (e.g. ?query or /123 message id)
+	if i := strings.IndexAny(s, "/?#"); i >= 0 {
+		s = s[:i]
+	}
+	return s
+}
+
+// fetchChannelProxies downloads the public web preview of a channel and extracts proxy links.
+func fetchChannelProxies(ctx context.Context, channel string) ([]string, error) {
+	url := "https://t.me/s/" + channel
+	ctx, cancel := context.WithTimeout(ctx, channelFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, channelBodyLimit))
+	if err != nil {
+		return nil, err
+	}
+
+	matches := proxyLinkRe.FindAllString(string(body), -1)
+	links := make([]string, 0, len(matches))
+	for _, m := range matches {
+		links = append(links, html.UnescapeString(m))
+	}
+	return links, nil
 }
 
 func jsonResponse(w http.ResponseWriter, status int, v interface{}) {
@@ -473,6 +550,84 @@ func main() {
 		wg.Wait()
 		log.Printf("STREAM DONE %d/%d working", working, total)
 		sendEvent("done", map[string]int{"working": working, "total": total})
+	}))
+
+	mux.HandleFunc("/fetch-channels", recoverMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
+
+		var req FetchChannelsRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			jsonResponse(w, http.StatusBadRequest, FetchChannelsResponse{})
+			return
+		}
+
+		// Normalize + dedupe channel names
+		seenCh := make(map[string]struct{})
+		var channels []string
+		for _, c := range req.Channels {
+			name := normalizeChannel(c)
+			if name == "" {
+				continue
+			}
+			if _, ok := seenCh[name]; ok {
+				continue
+			}
+			seenCh[name] = struct{}{}
+			channels = append(channels, name)
+			if len(channels) >= maxChannels {
+				break
+			}
+		}
+
+		log.Printf("FETCH START %d channels", len(channels))
+		start := time.Now()
+
+		type chResult struct {
+			links []string
+			err   error
+			name  string
+		}
+		resultsCh := make(chan chResult, len(channels))
+		var wg sync.WaitGroup
+		for _, name := range channels {
+			wg.Add(1)
+			go func(ch string) {
+				defer wg.Done()
+				links, err := fetchChannelProxies(r.Context(), ch)
+				resultsCh <- chResult{links: links, err: err, name: ch}
+			}(name)
+		}
+		wg.Wait()
+		close(resultsCh)
+
+		seenLink := make(map[string]struct{})
+		var allLinks []string
+		var errs []string
+		for res := range resultsCh {
+			if res.err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", res.name, res.err))
+				continue
+			}
+			for _, l := range res.links {
+				if _, ok := seenLink[l]; ok {
+					continue
+				}
+				seenLink[l] = struct{}{}
+				allLinks = append(allLinks, l)
+			}
+		}
+
+		log.Printf("FETCH DONE %d links from %d channels (%v)", len(allLinks), len(channels), time.Since(start))
+		jsonResponse(w, http.StatusOK, FetchChannelsResponse{
+			Links:  allLinks,
+			Count:  len(allLinks),
+			Errors: errs,
+		})
 	}))
 
 	embeddedFS, err := fs.Sub(publicFS, "public")

--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ type FetchChannelsResponse struct {
 	Links  []string `json:"links"`
 	Count  int      `json:"count"`
 	Errors []string `json:"errors,omitempty"`
+	Notes  []string `json:"notes,omitempty"`
 }
 
 const maxChannels = 30

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -195,6 +195,40 @@ html[dir="rtl"] .lang-select {
     font-family: var(--font-en);
 }
 
+/* ===== Channels ===== */
+.channels-bar {
+    margin-bottom: 16px;
+}
+
+.channels-bar label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+textarea.channels-input {
+    height: 80px;
+    font-size: 12px;
+}
+
+.channels-bar .btn-row {
+    margin-top: 8px;
+}
+
+.btn-fetch {
+    background: linear-gradient(135deg, rgba(139,92,246,0.9), rgba(168,85,247,0.9));
+    box-shadow: 0 4px 16px rgba(139,92,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);
+}
+.btn-fetch:hover:not(:disabled) {
+    background: linear-gradient(135deg, rgba(124,58,237,0.95), rgba(147,51,234,0.95));
+    box-shadow: 0 6px 20px rgba(139,92,246,0.4), inset 0 1px 0 rgba(255,255,255,0.15);
+}
+[data-theme="light"] .btn-fetch {
+    background: linear-gradient(135deg, rgba(124,58,237,0.92), rgba(147,51,234,0.92));
+    box-shadow: 0 4px 12px rgba(124,58,237,0.2), inset 0 1px 0 rgba(255,255,255,0.3);
+}
+
 /* ===== Grid ===== */
 .grid {
     display: grid;

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -212,6 +212,22 @@ textarea.channels-input {
     font-size: 12px;
 }
 
+.proxy-input {
+    width: 100%;
+    margin-top: 8px;
+    background-color: var(--input);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 10px 12px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    outline: none;
+    box-sizing: border-box;
+    transition: border-color var(--transition);
+}
+.proxy-input:focus { border-color: var(--accent); }
+
 .channels-bar .btn-row {
     margin-top: 8px;
 }

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -232,6 +232,51 @@ textarea.channels-input {
     margin-top: 8px;
 }
 
+.tg-limit-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+}
+.tg-limit-row label {
+    font-size: 0.9rem;
+    color: var(--text-muted, var(--text));
+}
+.tg-limit-row input {
+    width: 80px;
+    padding: 6px 8px;
+    background-color: var(--input);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    text-align: center;
+}
+.tg-limit-row input:focus { border-color: var(--accent); }
+
+.tg-section {
+    margin-top: 12px;
+    padding: 10px 12px;
+    background-color: var(--input);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+}
+.tg-section > summary,
+.tg-adv > summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--text);
+}
+.tg-adv {
+    margin-top: 8px;
+}
+.tg-hint {
+    margin: 8px 0 4px;
+    font-size: 11px;
+    line-height: 1.6;
+    color: var(--muted, #9aa);
+}
+
 .btn-fetch {
     background: linear-gradient(135deg, rgba(139,92,246,0.9), rgba(168,85,247,0.9));
     box-shadow: 0 4px 16px rgba(139,92,246,0.3), inset 0 1px 0 rgba(255,255,255,0.15);

--- a/public/index.html
+++ b/public/index.html
@@ -56,10 +56,47 @@
         <div class="channels-bar">
             <label data-i18n="channelsLabel">📡 کانال‌های پراکسی تلگرام (هر خط یک کانال)</label>
             <textarea id="inputChannels" class="channels-input" placeholder="MTProxiess&#10;@DirectProxy&#10;https://t.me/s/socks5_telegram"></textarea>
-            <input type="text" id="inputProxyUrl" class="proxy-input" placeholder="پراکسی برای دور زدن فیلترینگ (اختیاری): socks5://127.0.0.1:10808" dir="ltr">
-            <div class="btn-row">
-                <button class="btn-fetch" id="fetchBtn" onclick="fetchFromChannels()" data-i18n="fetchBtn">⬇ دریافت پراکسی از کانال‌ها</button>
+            <input type="text" id="tgProxyLink" class="proxy-input" placeholder="پراکسی MTProto سالم: tg://proxy?server=...&port=...&secret=..." dir="ltr">
+            <div class="tg-limit-row">
+                <label for="tgPerChannel" data-i18n="perChannelLabel">تعداد پراکسی از هر کانال (جدیدترین‌ها):</label>
+                <input type="number" id="tgPerChannel" min="1" max="100" value="10" dir="ltr">
             </div>
+            <div class="btn-row">
+                <button class="btn-fetch" id="fetchBtn" onclick="fetchViaTelegram()" data-i18n="fetchBtn">⬇ دریافت پراکسی از کانال‌ها</button>
+            </div>
+
+            <details class="tg-section" id="tgSection">
+                <summary data-i18n="tgSummary">🔐 ورود به حساب تلگرام (یک‌بار لازم است)</summary>
+                <p class="tg-hint" data-i18n="tgHint">دریافت پراکسی‌ها مستقیماً از API تلگرام و تونل‌شده از طریق پراکسی MTProto بالا انجام می‌شود. برای این کار باید یک‌بار با حساب تلگرام وارد شوید. اطلاعات ورود فقط روی همین سیستم ذخیره می‌شود و هرگز در گیت قرار نمی‌گیرد.</p>
+
+                <input type="text" id="tgPhone" class="proxy-input" placeholder="+98912xxxxxxx" dir="ltr">
+
+                <details class="tg-adv">
+                    <summary data-i18n="tgAdv">تنظیمات پیشرفته (api_id / api_hash)</summary>
+                    <p class="tg-hint" data-i18n="tgAdvHint">برای پایداری بیشتر، یک api_id و api_hash از my.telegram.org بسازید. خالی بگذارید تا از مقادیر پیش‌فرض استفاده شود.</p>
+                    <input type="text" id="tgAppId" class="proxy-input" placeholder="api_id" dir="ltr">
+                    <input type="text" id="tgAppHash" class="proxy-input" placeholder="api_hash" dir="ltr">
+                </details>
+
+                <div class="btn-row">
+                    <button class="btn-fetch" id="tgLoginBtn" onclick="tgStartLogin()" data-i18n="tgLoginBtn">ورود</button>
+                    <button class="btn-pause" id="tgLogoutBtn" onclick="tgLogout()" data-i18n="tgLogoutBtn">خروج</button>
+                </div>
+
+                <div id="tgCodeRow" class="btn-row" style="display:none">
+                    <input type="text" id="tgCode" class="proxy-input" placeholder="کد تایید" dir="ltr">
+                    <button class="btn-fetch" id="tgCodeBtn" onclick="tgSubmitCode()" data-i18n="tgCodeBtn">تایید کد</button>
+                </div>
+                <div id="tgPwdRow" class="btn-row" style="display:none">
+                    <input type="password" id="tgPwd" class="proxy-input" placeholder="رمز دو مرحله‌ای (2FA)" dir="ltr">
+                    <button class="btn-fetch" id="tgPwdBtn" onclick="tgSubmitPassword()" data-i18n="tgPwdBtn">تایید رمز</button>
+                </div>
+                <div id="tgCaptchaRow" style="display:none;margin-top:10px">
+                    <p class="tg-hint" data-i18n="tgCaptchaHint">برای ادامه، تأیید امنیتی reCAPTCHA را کامل کنید:</p>
+                    <div id="tgCaptcha"></div>
+                </div>
+                <div class="status-text" id="tgStatus"></div>
+            </details>
         </div>
 
         <div class="progress-box"><div class="progress-bar" id="progressBar"></div></div>

--- a/public/index.html
+++ b/public/index.html
@@ -58,8 +58,8 @@
             <textarea id="inputChannels" class="channels-input" placeholder="MTProxiess&#10;@DirectProxy&#10;https://t.me/s/socks5_telegram"></textarea>
             <input type="text" id="tgProxyLink" class="proxy-input" placeholder="پراکسی MTProto سالم: tg://proxy?server=...&port=...&secret=..." dir="ltr">
             <div class="tg-limit-row">
-                <label for="tgPerChannel" data-i18n="perChannelLabel">تعداد پراکسی از هر کانال (جدیدترین‌ها):</label>
-                <input type="number" id="tgPerChannel" min="1" max="100" value="10" dir="ltr">
+                <label for="tgPerChannel" data-i18n="perChannelLabel">تعداد پراکسی از هر کانال (۰ = همه، جدیدترین‌ها):</label>
+                <input type="number" id="tgPerChannel" min="0" max="1000" value="0" dir="ltr">
             </div>
             <div class="btn-row">
                 <button class="btn-fetch" id="fetchBtn" onclick="fetchViaTelegram()" data-i18n="fetchBtn">⬇ دریافت پراکسی از کانال‌ها</button>

--- a/public/index.html
+++ b/public/index.html
@@ -53,6 +53,14 @@
             </div>
         </div>
         
+        <div class="channels-bar">
+            <label data-i18n="channelsLabel">📡 کانال‌های پراکسی تلگرام (هر خط یک کانال)</label>
+            <textarea id="inputChannels" class="channels-input" placeholder="MTProxiess&#10;@DirectProxy&#10;https://t.me/s/socks5_telegram"></textarea>
+            <div class="btn-row">
+                <button class="btn-fetch" id="fetchBtn" onclick="fetchFromChannels()" data-i18n="fetchBtn">⬇ دریافت پراکسی از کانال‌ها</button>
+            </div>
+        </div>
+
         <div class="progress-box"><div class="progress-bar" id="progressBar"></div></div>
         <div class="status-text" id="statusText" data-i18n="ready">آماده...</div>
     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -56,6 +56,7 @@
         <div class="channels-bar">
             <label data-i18n="channelsLabel">📡 کانال‌های پراکسی تلگرام (هر خط یک کانال)</label>
             <textarea id="inputChannels" class="channels-input" placeholder="MTProxiess&#10;@DirectProxy&#10;https://t.me/s/socks5_telegram"></textarea>
+            <input type="text" id="inputProxyUrl" class="proxy-input" placeholder="پراکسی برای دور زدن فیلترینگ (اختیاری): socks5://127.0.0.1:10808" dir="ltr">
             <div class="btn-row">
                 <button class="btn-fetch" id="fetchBtn" onclick="fetchFromChannels()" data-i18n="fetchBtn">⬇ دریافت پراکسی از کانال‌ها</button>
             </div>

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -31,7 +31,7 @@ const translations = {
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
         proxyPlaceholder: "پراکسی برای دور زدن فیلترینگ (اختیاری): socks5://127.0.0.1:10808",
         fetchBtn: "⬇ دریافت پراکسی از کانال‌ها",
-        perChannelLabel: "تعداد پراکسی از هر کانال (جدیدترین‌ها):",
+        perChannelLabel: "تعداد پراکسی از هر کانال (۰ = همه، جدیدترین‌ها):",
         fetchingBtn: "⏳ در حال دریافت...",
         toastNoChannels: "⚠️ هیچ کانالی وارد نشده است!",
         toastFetched: "✅ {n} پراکسی از کانال‌ها دریافت شد!",
@@ -70,7 +70,7 @@ const translations = {
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
         proxyPlaceholder: "Proxy to bypass filtering (optional): socks5://127.0.0.1:10808",
         fetchBtn: "⬇ Fetch proxies from channels",
-        perChannelLabel: "Proxies per channel (newest):",
+        perChannelLabel: "Proxies per channel (0 = all, newest):",
         fetchingBtn: "⏳ Fetching...",
         toastNoChannels: "⚠️ No channels entered!",
         toastFetched: "✅ Fetched {n} proxies from channels!",
@@ -109,7 +109,7 @@ const translations = {
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
         proxyPlaceholder: "Прокси для обхода блокировки (опц.): socks5://127.0.0.1:10808",
         fetchBtn: "⬇ Получить прокси из каналов",
-        perChannelLabel: "Прокси с канала (новейшие):",
+        perChannelLabel: "Прокси с канала (0 = все, новейшие):",
         fetchingBtn: "⏳ Загрузка...",
         toastNoChannels: "⚠️ Каналы не указаны!",
         toastFetched: "✅ Получено {n} прокси из каналов!",
@@ -148,7 +148,7 @@ const translations = {
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
         proxyPlaceholder: "用于绕过封锁的代理（可选）: socks5://127.0.0.1:10808",
         fetchBtn: "⬇ 从频道获取代理",
-        perChannelLabel: "每个频道的代理数（最新）:",
+        perChannelLabel: "每个频道的代理数（0 = 全部，最新）:",
         fetchingBtn: "⏳ 获取中...",
         toastNoChannels: "⚠️ 未输入频道!",
         toastFetched: "✅ 已从频道获取 {n} 个代理!",
@@ -596,17 +596,17 @@ async function fetchViaTelegram() {
     // Remember the MTProto proxy link so it survives reloads.
     localStorage.setItem('fetchProxy', document.getElementById('tgProxyLink').value.trim());
 
-    // How many (newest) proxies to take from each channel.
+    // How many (newest) proxies to take from each channel; 0 = all.
     let perChannel = parseInt(document.getElementById('tgPerChannel').value, 10);
-    if (isNaN(perChannel) || perChannel < 1) perChannel = 10;
-    if (perChannel > 100) perChannel = 100;
+    if (isNaN(perChannel) || perChannel < 0) perChannel = 0;
+    if (perChannel > 1000) perChannel = 1000;
     localStorage.setItem('tgPerChannel', perChannel);
 
     const btn = document.getElementById('fetchBtn');
     btn.disabled = true;
     btn.innerText = t.fetchingBtn;
     tgSetStatus('در حال دریافت از طریق تلگرام...');
-    log(`Fetching up to ${perChannel} newest proxies from ${channels.length} channel(s) via Telegram...`);
+    log(`Fetching ${perChannel === 0 ? 'all' : 'up to ' + perChannel} newest proxies from ${channels.length} channel(s) via Telegram...`);
 
     try {
         const res = await fetch('/fetch-channels-tg', {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -814,7 +814,9 @@ async function startCheck() {
             return;
         }
 
-        log(`Parsed ${validLinks.length} valid links. Skipped ${skippedCount} bad links.`);
+        log(`Parsed ${validLinks.length} valid links.` + (skippedCount > 0
+            ? ` Skipped ${skippedCount} decoy/invalid proxies (padded or over-long secrets — they never connect).`
+            : ''));
 
         workingProxies = [];
         document.getElementById('outputProxies').value = '';

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -26,7 +26,15 @@ const translations = {
         exportJsonBtn: "💾 JSON",
         toastExported: "✅ فایل دانلود شد!",
         concurrencyLabel: "تعداد همزمان",
-        timeoutLabel: "تایم‌اوت (ثانیه)"
+        timeoutLabel: "تایم‌اوت (ثانیه)",
+        channelsLabel: "📡 کانال‌های پراکسی تلگرام (هر خط یک کانال)",
+        channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
+        fetchBtn: "⬇ دریافت پراکسی از کانال‌ها",
+        fetchingBtn: "⏳ در حال دریافت...",
+        toastNoChannels: "⚠️ هیچ کانالی وارد نشده است!",
+        toastFetched: "✅ {n} پراکسی از کانال‌ها دریافت شد!",
+        toastFetchNone: "😔 هیچ پراکسی‌ای در کانال‌ها پیدا نشد.",
+        toastFetchError: "⛔ خطا در دریافت از کانال‌ها."
     },
     en: {
         title: "MTProto Pro Checker",
@@ -55,7 +63,15 @@ const translations = {
         exportJsonBtn: "💾 JSON",
         toastExported: "✅ File downloaded!",
         concurrencyLabel: "Concurrent",
-        timeoutLabel: "Timeout (sec)"
+        timeoutLabel: "Timeout (sec)",
+        channelsLabel: "📡 Telegram proxy channels (one per line)",
+        channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
+        fetchBtn: "⬇ Fetch proxies from channels",
+        fetchingBtn: "⏳ Fetching...",
+        toastNoChannels: "⚠️ No channels entered!",
+        toastFetched: "✅ Fetched {n} proxies from channels!",
+        toastFetchNone: "😔 No proxies found in channels.",
+        toastFetchError: "⛔ Failed to fetch from channels."
     },
     ru: {
         title: "MTProto Pro Checker",
@@ -84,7 +100,15 @@ const translations = {
         exportJsonBtn: "💾 JSON",
         toastExported: "✅ Файл загружен!",
         concurrencyLabel: "Одновременно",
-        timeoutLabel: "Тайм-аут (сек)"
+        timeoutLabel: "Тайм-аут (сек)",
+        channelsLabel: "📡 Telegram-каналы с прокси (по одному в строке)",
+        channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
+        fetchBtn: "⬇ Получить прокси из каналов",
+        fetchingBtn: "⏳ Загрузка...",
+        toastNoChannels: "⚠️ Каналы не указаны!",
+        toastFetched: "✅ Получено {n} прокси из каналов!",
+        toastFetchNone: "😔 Прокси в каналах не найдены.",
+        toastFetchError: "⛔ Ошибка получения из каналов."
     },
     zh: {
         title: "MTProto Pro Checker",
@@ -113,7 +137,15 @@ const translations = {
         exportJsonBtn: "💾 JSON",
         toastExported: "✅ 文件已下载!",
         concurrencyLabel: "并发数",
-        timeoutLabel: "超时（秒）"
+        timeoutLabel: "超时（秒）",
+        channelsLabel: "📡 Telegram 代理频道（每行一个）",
+        channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
+        fetchBtn: "⬇ 从频道获取代理",
+        fetchingBtn: "⏳ 获取中...",
+        toastNoChannels: "⚠️ 未输入频道!",
+        toastFetched: "✅ 已从频道获取 {n} 个代理!",
+        toastFetchNone: "😔 频道中未找到代理.",
+        toastFetchError: "⛔ 从频道获取失败."
     }
 };
 
@@ -152,6 +184,8 @@ function setLanguage(lang) {
 
     document.getElementById('inputProxies').placeholder = translations[lang].inputPlaceholder;
     document.getElementById('outputProxies').placeholder = translations[lang].outputPlaceholder;
+    const chEl = document.getElementById('inputChannels');
+    if (chEl) chEl.placeholder = translations[lang].channelsPlaceholder;
 }
 
 function updatePauseBtn() {
@@ -274,6 +308,64 @@ function openHelp() {
         zh: 'https://github.com/rahgozar94725/MTProto-Checker/blob/main/README_ZH.md'
     };
     window.open(urls[currentLang] || urls.en, '_blank', 'noopener');
+}
+
+async function fetchFromChannels() {
+    const t = translations[currentLang];
+    const btn = document.getElementById('fetchBtn');
+    const raw = document.getElementById('inputChannels').value;
+
+    const channels = raw.split('\n').map(s => s.trim()).filter(s => s.length > 0);
+    if (channels.length === 0) return showToast(t.toastNoChannels, true);
+
+    btn.disabled = true;
+    btn.innerText = t.fetchingBtn;
+    log(`Fetching proxies from ${channels.length} channel(s)...`);
+
+    try {
+        const response = await fetch('/fetch-channels', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ channels })
+        });
+        if (!response.ok) throw new Error('Server error ' + response.status);
+
+        const data = await response.json();
+        const links = data.links || [];
+
+        if (data.errors && data.errors.length) {
+            data.errors.forEach(e => log(`Channel error: ${e}`, true));
+        }
+
+        if (links.length === 0) {
+            showToast(t.toastFetchNone, true);
+            log('No proxies found in channels.');
+            return;
+        }
+
+        // Merge into the input textarea, de-duplicating against existing lines
+        const input = document.getElementById('inputProxies');
+        const existing = input.value.split('\n').map(s => s.trim()).filter(Boolean);
+        const seen = new Set(existing);
+        const added = [];
+        for (const l of links) {
+            if (!seen.has(l)) {
+                seen.add(l);
+                added.push(l);
+            }
+        }
+        const merged = existing.concat(added);
+        input.value = merged.join('\n');
+
+        log(`Fetched ${links.length} proxies (${added.length} new) from channels.`);
+        showToast(t.toastFetched.replace('{n}', added.length));
+    } catch (e) {
+        log(`FETCH ERROR: ${e.message}`, true);
+        showToast(t.toastFetchError, true);
+    } finally {
+        btn.disabled = false;
+        btn.innerText = t.fetchBtn;
+    }
 }
 
 function handleStartStop() {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -31,6 +31,7 @@ const translations = {
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
         proxyPlaceholder: "پراکسی برای دور زدن فیلترینگ (اختیاری): socks5://127.0.0.1:10808",
         fetchBtn: "⬇ دریافت پراکسی از کانال‌ها",
+        perChannelLabel: "تعداد پراکسی از هر کانال (جدیدترین‌ها):",
         fetchingBtn: "⏳ در حال دریافت...",
         toastNoChannels: "⚠️ هیچ کانالی وارد نشده است!",
         toastFetched: "✅ {n} پراکسی از کانال‌ها دریافت شد!",
@@ -69,6 +70,7 @@ const translations = {
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
         proxyPlaceholder: "Proxy to bypass filtering (optional): socks5://127.0.0.1:10808",
         fetchBtn: "⬇ Fetch proxies from channels",
+        perChannelLabel: "Proxies per channel (newest):",
         fetchingBtn: "⏳ Fetching...",
         toastNoChannels: "⚠️ No channels entered!",
         toastFetched: "✅ Fetched {n} proxies from channels!",
@@ -107,6 +109,7 @@ const translations = {
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
         proxyPlaceholder: "Прокси для обхода блокировки (опц.): socks5://127.0.0.1:10808",
         fetchBtn: "⬇ Получить прокси из каналов",
+        perChannelLabel: "Прокси с канала (новейшие):",
         fetchingBtn: "⏳ Загрузка...",
         toastNoChannels: "⚠️ Каналы не указаны!",
         toastFetched: "✅ Получено {n} прокси из каналов!",
@@ -145,6 +148,7 @@ const translations = {
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
         proxyPlaceholder: "用于绕过封锁的代理（可选）: socks5://127.0.0.1:10808",
         fetchBtn: "⬇ 从频道获取代理",
+        perChannelLabel: "每个频道的代理数（最新）:",
         fetchingBtn: "⏳ 获取中...",
         toastNoChannels: "⚠️ 未输入频道!",
         toastFetched: "✅ 已从频道获取 {n} 个代理!",
@@ -190,8 +194,6 @@ function setLanguage(lang) {
     document.getElementById('outputProxies').placeholder = translations[lang].outputPlaceholder;
     const chEl = document.getElementById('inputChannels');
     if (chEl) chEl.placeholder = translations[lang].channelsPlaceholder;
-    const pxEl = document.getElementById('inputProxyUrl');
-    if (pxEl) pxEl.placeholder = translations[lang].proxyPlaceholder;
 }
 
 function updatePauseBtn() {
@@ -282,11 +284,59 @@ document.getElementById('concurrencySelect').addEventListener('change', saveSett
 document.getElementById('timeoutSelect').addEventListener('change', saveSettings);
 loadSettings();
 
-// Restore saved fetch proxy
+// Restore the saved MTProto proxy link
 const savedProxy = localStorage.getItem('fetchProxy');
 if (savedProxy) {
-    const pxEl = document.getElementById('inputProxyUrl');
-    if (pxEl) pxEl.value = savedProxy;
+    const pxEl = document.getElementById('tgProxyLink');
+    if (pxEl && !pxEl.value) pxEl.value = savedProxy;
+}
+
+// ----- Channel list: persistence + de-duplication -----
+
+// channelKey normalizes a channel line (URL / @name / bare name) to a single
+// canonical key so duplicates collapse regardless of how they were written.
+function channelKey(line) {
+    let s = line.trim().toLowerCase();
+    s = s.replace(/^https?:\/\//, '').replace(/^t\.me\//, '').replace(/^telegram\.me\//, '');
+    s = s.replace(/^s\//, '').replace(/^@/, '');
+    const cut = s.search(/[/?#]/);
+    if (cut >= 0) s = s.slice(0, cut);
+    return s;
+}
+
+// dedupeChannels returns the non-empty channel lines with duplicates removed,
+// keeping the first occurrence of each.
+function dedupeChannels(raw) {
+    const seen = new Set();
+    const out = [];
+    for (const line of raw.split('\n')) {
+        const t = line.trim();
+        if (!t) continue;
+        const key = channelKey(t);
+        if (!key || seen.has(key)) continue;
+        seen.add(key);
+        out.push(t);
+    }
+    return out;
+}
+
+function saveChannels() {
+    localStorage.setItem('fetchChannels', document.getElementById('inputChannels').value);
+}
+
+// Restore the saved channel list and persist edits as the user types.
+const channelsEl = document.getElementById('inputChannels');
+if (channelsEl) {
+    const savedChannels = localStorage.getItem('fetchChannels');
+    if (savedChannels && !channelsEl.value.trim()) channelsEl.value = savedChannels;
+    channelsEl.addEventListener('input', saveChannels);
+}
+
+// Restore the saved per-channel proxy count.
+const perChannelEl = document.getElementById('tgPerChannel');
+if (perChannelEl) {
+    const savedPerChannel = localStorage.getItem('tgPerChannel');
+    if (savedPerChannel) perChannelEl.value = savedPerChannel;
 }
 
 function parseLink(link) {
@@ -323,70 +373,273 @@ function openHelp() {
     window.open(urls[currentLang] || urls.en, '_blank', 'noopener');
 }
 
-async function fetchFromChannels() {
+// ----- Telegram authenticated fetch -----
+
+function tgSetStatus(msg, isErr) {
+    const el = document.getElementById('tgStatus');
+    if (el) {
+        el.innerText = msg || '';
+        el.style.color = isErr ? 'var(--danger, #ff5c5c)' : '';
+    }
+}
+
+// Returns the MTProto proxy creds {server, port, secret} from the tg proxy
+// link field, or null if missing/invalid.
+function tgProxyCreds() {
+    const raw = document.getElementById('tgProxyLink').value.trim();
+    if (!raw) return null;
+    const parsed = parseLink(raw);
+    if (!parsed) return null;
+    return { server: parsed.server, port: Number(parsed.port), secret: parsed.secret };
+}
+
+// On page load, check for a session/credentials already saved on this machine
+// and resume from them so the user need not log in again. Reads local files
+// only (no network round-trip), so it is instant.
+async function tgResumeSession() {
+    try {
+        const res = await fetch('/tg/me');
+        const data = await res.json();
+        if (data.has_app_creds) {
+            const idEl = document.getElementById('tgAppId');
+            const hashEl = document.getElementById('tgAppHash');
+            if (idEl && !idEl.value) idEl.value = data.app_id;
+            if (hashEl && !hashEl.value) hashEl.value = data.app_hash;
+            // Open the advanced section so the restored values are visible.
+            const adv = document.querySelector('.tg-adv');
+            if (adv) adv.open = true;
+        }
+        if (data.has_session) {
+            tgSetStatus('✅ سشن ذخیره‌شده پیدا شد — وارد هستید. برای دریافت از کانال‌ها نیازی به ورود مجدد نیست.');
+            const loginBtn = document.getElementById('tgLoginBtn');
+            if (loginBtn) loginBtn.innerText = 'ورود مجدد';
+        }
+    } catch (e) { /* no saved session; leave the form as-is */ }
+}
+
+let tgPollTimer = null;
+
+async function tgPollLoginStatus() {
+    try {
+        const res = await fetch('/tg/login/status');
+        const data = await res.json();
+        const codeRow = document.getElementById('tgCodeRow');
+        const pwdRow = document.getElementById('tgPwdRow');
+        const captchaRow = document.getElementById('tgCaptchaRow');
+        codeRow.style.display = data.state === 'awaiting_code' ? '' : 'none';
+        pwdRow.style.display = data.state === 'awaiting_password' ? '' : 'none';
+        captchaRow.style.display = data.state === 'awaiting_captcha' ? '' : 'none';
+
+        if (data.state === 'awaiting_captcha') {
+            tgSetStatus('تأیید امنیتی reCAPTCHA لازم است. لطفاً آن را کامل کنید.');
+            tgRenderCaptcha(data.sitekey);
+        } else if (data.state === 'awaiting_code') {
+            tgSetStatus('کد تایید ارسال شد. کد را وارد کنید.');
+        } else if (data.state === 'awaiting_password') {
+            tgSetStatus('رمز دو مرحله‌ای (2FA) را وارد کنید.');
+        } else if (data.state === 'authorized') {
+            tgSetStatus('✅ ورود موفق. اکنون می‌توانید از کانال‌ها دریافت کنید.');
+            log('Telegram login successful.');
+            clearInterval(tgPollTimer); tgPollTimer = null;
+        } else if (data.state === 'failed') {
+            tgSetStatus('⛔ ورود ناموفق: ' + (data.error || ''), true);
+            log('Telegram login failed: ' + (data.error || ''), true);
+            clearInterval(tgPollTimer); tgPollTimer = null;
+        }
+    } catch (e) { /* keep polling */ }
+}
+
+async function tgStartLogin() {
+    const creds = tgProxyCreds();
+    if (!creds) return showToast('⚠️ لینک پراکسی MTProto سالم را وارد کنید.', true);
+    const phone = document.getElementById('tgPhone').value.trim();
+    if (!phone) return showToast('⚠️ شماره تلفن را وارد کنید.', true);
+
+    const body = { proxy: creds, phone };
+    const appId = document.getElementById('tgAppId').value.trim();
+    const appHash = document.getElementById('tgAppHash').value.trim();
+    if (appId && appHash) { body.app_id = Number(appId); body.app_hash = appHash; }
+
+    // Reset any captcha widget from a previous attempt so it re-renders fresh.
+    tgCaptchaSitekey = null;
+    document.getElementById('tgCaptchaRow').style.display = 'none';
+
+    tgSetStatus('در حال اتصال و ارسال کد...');
+    try {
+        const res = await fetch('/tg/login/start', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+        const data = await res.json();
+        if (data.error) { tgSetStatus('⛔ ' + data.error, true); return; }
+        if (tgPollTimer) clearInterval(tgPollTimer);
+        tgPollTimer = setInterval(tgPollLoginStatus, 1500);
+        tgPollLoginStatus();
+    } catch (e) {
+        tgSetStatus('⛔ ' + e.message, true);
+    }
+}
+
+async function tgSubmitCode() {
+    const code = document.getElementById('tgCode').value.trim();
+    if (!code) return;
+    try {
+        const res = await fetch('/tg/login/code', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ code })
+        });
+        const data = await res.json();
+        if (data.error) { tgSetStatus('⛔ ' + data.error, true); return; }
+        tgSetStatus('در حال بررسی کد...');
+    } catch (e) { tgSetStatus('⛔ ' + e.message, true); }
+}
+
+async function tgSubmitPassword() {
+    const password = document.getElementById('tgPwd').value;
+    try {
+        const res = await fetch('/tg/login/password', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password })
+        });
+        const data = await res.json();
+        if (data.error) { tgSetStatus('⛔ ' + data.error, true); return; }
+        tgSetStatus('در حال بررسی رمز...');
+    } catch (e) { tgSetStatus('⛔ ' + e.message, true); }
+}
+
+// ---- Telegram login reCAPTCHA handling ----
+let tgCaptchaWidgetId = null;
+let tgCaptchaSitekey = null;
+let tgRecaptchaLoading = false;
+
+// Loads Google's reCAPTCHA script on demand and resolves once grecaptcha.render
+// is available.
+function tgLoadRecaptcha() {
+    return new Promise((resolve, reject) => {
+        if (window.grecaptcha && window.grecaptcha.render) return resolve();
+        const waitReady = () => {
+            const iv = setInterval(() => {
+                if (window.grecaptcha && window.grecaptcha.render) { clearInterval(iv); resolve(); }
+            }, 100);
+            setTimeout(() => { clearInterval(iv); if (!(window.grecaptcha && window.grecaptcha.render)) reject(new Error('reCAPTCHA load timeout')); }, 15000);
+        };
+        if (tgRecaptchaLoading) return waitReady();
+        tgRecaptchaLoading = true;
+        const s = document.createElement('script');
+        s.src = 'https://www.google.com/recaptcha/api.js?render=explicit';
+        s.async = true; s.defer = true;
+        s.onload = waitReady;
+        s.onerror = () => reject(new Error('failed to load reCAPTCHA script'));
+        document.head.appendChild(s);
+    });
+}
+
+// Renders the reCAPTCHA widget for the given Telegram site key. On solve, the
+// token is posted back to the server which retries send-code with it.
+async function tgRenderCaptcha(sitekey) {
+    if (!sitekey || tgCaptchaSitekey === sitekey) return; // already rendered for this key
+    try {
+        await tgLoadRecaptcha();
+    } catch (e) {
+        tgSetStatus('⛔ بارگذاری reCAPTCHA ناموفق بود (احتمالاً دسترسی به گوگل مسدود است). با VPN/پراکسی روی مرورگر دوباره تلاش کنید.', true);
+        return;
+    }
+    const container = document.getElementById('tgCaptcha');
+    container.innerHTML = '';
+    try {
+        tgCaptchaWidgetId = window.grecaptcha.render(container, {
+            sitekey: sitekey,
+            callback: tgSubmitCaptcha
+        });
+        tgCaptchaSitekey = sitekey;
+    } catch (e) {
+        tgSetStatus('⛔ نمایش reCAPTCHA ناموفق بود: ' + e.message, true);
+    }
+}
+
+async function tgSubmitCaptcha(token) {
+    if (!token) return;
+    tgSetStatus('در حال ارسال تأیید امنیتی...');
+    try {
+        const res = await fetch('/tg/login/captcha', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token })
+        });
+        const data = await res.json();
+        if (data.error) { tgSetStatus('⛔ ' + data.error, true); return; }
+        tgSetStatus('تأیید امنیتی ارسال شد. در حال ارسال کد...');
+    } catch (e) { tgSetStatus('⛔ ' + e.message, true); }
+}
+
+async function tgLogout() {
+    try {
+        await fetch('/tg/logout', { method: 'POST' });
+        tgSetStatus('از حساب خارج شدید. session حذف شد.');
+        const loginBtn = document.getElementById('tgLoginBtn');
+        if (loginBtn) loginBtn.innerText = 'ورود';
+        log('Telegram session removed.');
+    } catch (e) { tgSetStatus('⛔ ' + e.message, true); }
+}
+
+async function fetchViaTelegram() {
     const t = translations[currentLang];
-    const btn = document.getElementById('fetchBtn');
-    const raw = document.getElementById('inputChannels').value;
+    const creds = tgProxyCreds();
+    if (!creds) return showToast('⚠️ لینک پراکسی MTProto سالم را وارد کنید.', true);
 
-    const channels = raw.split('\n').map(s => s.trim()).filter(s => s.length > 0);
+    const chEl = document.getElementById('inputChannels');
+    const channels = dedupeChannels(chEl.value);
     if (channels.length === 0) return showToast(t.toastNoChannels, true);
+    // Write the de-duplicated list back and persist it for next time.
+    chEl.value = channels.join('\n');
+    saveChannels();
 
-    const proxy = document.getElementById('inputProxyUrl').value.trim();
-    localStorage.setItem('fetchProxy', proxy);
+    // Remember the MTProto proxy link so it survives reloads.
+    localStorage.setItem('fetchProxy', document.getElementById('tgProxyLink').value.trim());
 
+    // How many (newest) proxies to take from each channel.
+    let perChannel = parseInt(document.getElementById('tgPerChannel').value, 10);
+    if (isNaN(perChannel) || perChannel < 1) perChannel = 10;
+    if (perChannel > 100) perChannel = 100;
+    localStorage.setItem('tgPerChannel', perChannel);
+
+    const btn = document.getElementById('fetchBtn');
     btn.disabled = true;
     btn.innerText = t.fetchingBtn;
-    log(`Fetching proxies from ${channels.length} channel(s)${proxy ? ' via proxy' : ''}...`);
+    tgSetStatus('در حال دریافت از طریق تلگرام...');
+    log(`Fetching up to ${perChannel} newest proxies from ${channels.length} channel(s) via Telegram...`);
 
     try {
-        const response = await fetch('/fetch-channels', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ channels, proxy })
+        const res = await fetch('/fetch-channels-tg', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ channels, proxy: creds, limit: perChannel })
         });
-        if (!response.ok) throw new Error('Server error ' + response.status);
-
-        const data = await response.json();
+        const data = await res.json();
         const links = data.links || [];
 
         if (data.errors && data.errors.length) {
-            data.errors.forEach(e => log(`Channel error: ${e}`, true));
+            data.errors.forEach(e => log(`TG channel error: ${e}`, true));
         }
-
         if (links.length === 0) {
-            // Distinguish "couldn't reach channels" from "channels had no proxies"
-            if (data.errors && data.errors.length >= channels.length) {
-                showToast(t.toastFetchError, true);
-                log(`All ${channels.length} channel(s) failed. First error: ${data.errors[0]}`, true);
-            } else if (data.errors && data.errors.length) {
-                showToast(t.toastFetchError, true);
-                log(`Some channels failed, none returned proxies. First error: ${data.errors[0]}`, true);
-            } else {
-                showToast(t.toastFetchNone, true);
-                log('Channels reachable but contained no proxy links.');
-            }
+            showToast(t.toastFetchNone, true);
+            tgSetStatus('چیزی دریافت نشد.' + (data.errors && data.errors.length ? ' ' + data.errors[0] : ''), true);
             return;
         }
 
-        // Merge into the input textarea, de-duplicating against existing lines
         const input = document.getElementById('inputProxies');
         const existing = input.value.split('\n').map(s => s.trim()).filter(Boolean);
         const seen = new Set(existing);
         const added = [];
         for (const l of links) {
-            if (!seen.has(l)) {
-                seen.add(l);
-                added.push(l);
-            }
+            if (!seen.has(l)) { seen.add(l); added.push(l); }
         }
-        const merged = existing.concat(added);
-        input.value = merged.join('\n');
-
-        log(`Fetched ${links.length} proxies (${added.length} new) from channels.`);
+        input.value = existing.concat(added).join('\n');
+        log(`Fetched ${links.length} proxies (${added.length} new) via Telegram.`);
         showToast(t.toastFetched.replace('{n}', added.length));
+        tgSetStatus(`✅ ${added.length} پراکسی جدید دریافت شد.`);
     } catch (e) {
-        log(`FETCH ERROR: ${e.message}`, true);
+        log(`TG FETCH ERROR: ${e.message}`, true);
         showToast(t.toastFetchError, true);
+        tgSetStatus('⛔ ' + e.message, true);
     } finally {
         btn.disabled = false;
         btn.innerText = t.fetchBtn;
@@ -740,6 +993,9 @@ function exportResults(format) {
     URL.revokeObjectURL(url);
     showToast(translations[currentLang].toastExported || 'Exported!');
 }
+
+// Resume any saved Telegram session/credentials on startup.
+tgResumeSession();
 
 const soundCheck = document.getElementById('soundCheck');
 if (soundCheck) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -338,8 +338,17 @@ async function fetchFromChannels() {
         }
 
         if (links.length === 0) {
-            showToast(t.toastFetchNone, true);
-            log('No proxies found in channels.');
+            // Distinguish "couldn't reach channels" from "channels had no proxies"
+            if (data.errors && data.errors.length >= channels.length) {
+                showToast(t.toastFetchError, true);
+                log(`All ${channels.length} channel(s) failed. First error: ${data.errors[0]}`, true);
+            } else if (data.errors && data.errors.length) {
+                showToast(t.toastFetchError, true);
+                log(`Some channels failed, none returned proxies. First error: ${data.errors[0]}`, true);
+            } else {
+                showToast(t.toastFetchNone, true);
+                log('Channels reachable but contained no proxy links.');
+            }
             return;
         }
 

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -29,6 +29,7 @@ const translations = {
         timeoutLabel: "تایم‌اوت (ثانیه)",
         channelsLabel: "📡 کانال‌های پراکسی تلگرام (هر خط یک کانال)",
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
+        proxyPlaceholder: "پراکسی برای دور زدن فیلترینگ (اختیاری): socks5://127.0.0.1:10808",
         fetchBtn: "⬇ دریافت پراکسی از کانال‌ها",
         fetchingBtn: "⏳ در حال دریافت...",
         toastNoChannels: "⚠️ هیچ کانالی وارد نشده است!",
@@ -66,6 +67,7 @@ const translations = {
         timeoutLabel: "Timeout (sec)",
         channelsLabel: "📡 Telegram proxy channels (one per line)",
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
+        proxyPlaceholder: "Proxy to bypass filtering (optional): socks5://127.0.0.1:10808",
         fetchBtn: "⬇ Fetch proxies from channels",
         fetchingBtn: "⏳ Fetching...",
         toastNoChannels: "⚠️ No channels entered!",
@@ -103,6 +105,7 @@ const translations = {
         timeoutLabel: "Тайм-аут (сек)",
         channelsLabel: "📡 Telegram-каналы с прокси (по одному в строке)",
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
+        proxyPlaceholder: "Прокси для обхода блокировки (опц.): socks5://127.0.0.1:10808",
         fetchBtn: "⬇ Получить прокси из каналов",
         fetchingBtn: "⏳ Загрузка...",
         toastNoChannels: "⚠️ Каналы не указаны!",
@@ -140,6 +143,7 @@ const translations = {
         timeoutLabel: "超时（秒）",
         channelsLabel: "📡 Telegram 代理频道（每行一个）",
         channelsPlaceholder: "MTProxiess\n@DirectProxy\nhttps://t.me/s/socks5_telegram",
+        proxyPlaceholder: "用于绕过封锁的代理（可选）: socks5://127.0.0.1:10808",
         fetchBtn: "⬇ 从频道获取代理",
         fetchingBtn: "⏳ 获取中...",
         toastNoChannels: "⚠️ 未输入频道!",
@@ -186,6 +190,8 @@ function setLanguage(lang) {
     document.getElementById('outputProxies').placeholder = translations[lang].outputPlaceholder;
     const chEl = document.getElementById('inputChannels');
     if (chEl) chEl.placeholder = translations[lang].channelsPlaceholder;
+    const pxEl = document.getElementById('inputProxyUrl');
+    if (pxEl) pxEl.placeholder = translations[lang].proxyPlaceholder;
 }
 
 function updatePauseBtn() {
@@ -276,6 +282,13 @@ document.getElementById('concurrencySelect').addEventListener('change', saveSett
 document.getElementById('timeoutSelect').addEventListener('change', saveSettings);
 loadSettings();
 
+// Restore saved fetch proxy
+const savedProxy = localStorage.getItem('fetchProxy');
+if (savedProxy) {
+    const pxEl = document.getElementById('inputProxyUrl');
+    if (pxEl) pxEl.value = savedProxy;
+}
+
 function parseLink(link) {
     try {
         let cleanLink = link.trim().replace('.&', '&');
@@ -318,15 +331,18 @@ async function fetchFromChannels() {
     const channels = raw.split('\n').map(s => s.trim()).filter(s => s.length > 0);
     if (channels.length === 0) return showToast(t.toastNoChannels, true);
 
+    const proxy = document.getElementById('inputProxyUrl').value.trim();
+    localStorage.setItem('fetchProxy', proxy);
+
     btn.disabled = true;
     btn.innerText = t.fetchingBtn;
-    log(`Fetching proxies from ${channels.length} channel(s)...`);
+    log(`Fetching proxies from ${channels.length} channel(s)${proxy ? ' via proxy' : ''}...`);
 
     try {
         const response = await fetch('/fetch-channels', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ channels })
+            body: JSON.stringify({ channels, proxy })
         });
         if (!response.ok) throw new Error('Server error ' + response.status);
 

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -616,6 +616,9 @@ async function fetchViaTelegram() {
         const data = await res.json();
         const links = data.links || [];
 
+        if (data.notes && data.notes.length) {
+            data.notes.forEach(n => log(`📊 ${n}`));
+        }
         if (data.errors && data.errors.length) {
             data.errors.forEach(e => log(`TG channel error: ${e}`, true));
         }

--- a/tgfetch.go
+++ b/tgfetch.go
@@ -34,10 +34,10 @@ import (
 // ----------------------------------------------------------------------------
 
 const (
-	perChannelDefault   = 10  // proxies taken per channel when unspecified
-	perChannelMax       = 100 // hard cap on proxies taken per channel
-	historyScanMessages = 100 // recent messages scanned to fill the quota
-	tgFetchTimeout      = 90 * time.Second
+	perChannelMax   = 1000 // hard cap on proxies taken per channel
+	historyPageSize = 100  // Telegram's max messages per getHistory call
+	maxScanMessages = 1500 // safety cap on messages paged through per channel
+	tgFetchTimeout  = 120 * time.Second
 )
 
 // tgConfigDir returns the per-user directory holding the session and app
@@ -533,8 +533,9 @@ func extractProxyLinksFromMessage(msg *tg.Message) []string {
 }
 
 // fetchChannelViaTG returns up to maxProxies proxy links from a channel,
-// taking the most recent ones first (Telegram history is newest-first). It
-// scans message history until the quota is filled or the messages run out.
+// newest first (maxProxies <= 0 means "as many as possible"). Telegram caps a
+// single getHistory to 100 messages, so we page backwards with OffsetID until
+// the quota is filled, the channel runs out, or the scan safety cap is hit.
 func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxProxies int) ([]string, error) {
 	resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: channel})
 	if err != nil {
@@ -561,35 +562,62 @@ func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxP
 		return nil, errors.New("not a channel/group, or no access")
 	}
 
-	hist, err := api.MessagesGetHistory(ctx, &tg.MessagesGetHistoryRequest{
-		Peer:  peer,
-		Limit: historyScanMessages,
-	})
-	if err != nil {
-		return nil, errors.Wrap(err, "get history")
-	}
-	modified, ok := hist.AsModified()
-	if !ok {
-		return nil, errors.New("unexpected history response")
-	}
-
 	var links []string
 	seen := make(map[string]struct{})
-	for _, m := range modified.GetMessages() { // newest first
-		msg, ok := m.(*tg.Message)
-		if !ok {
-			continue
+	offsetID := 0
+	scanned := 0
+
+	for scanned < maxScanMessages {
+		hist, err := api.MessagesGetHistory(ctx, &tg.MessagesGetHistoryRequest{
+			Peer:     peer,
+			Limit:    historyPageSize,
+			OffsetID: offsetID,
+		})
+		if err != nil {
+			if len(links) > 0 {
+				break // keep what we already gathered instead of failing the channel
+			}
+			return nil, errors.Wrap(err, "get history")
 		}
-		for _, l := range extractProxyLinksFromMessage(msg) {
-			if _, dup := seen[l]; dup {
+		modified, ok := hist.AsModified()
+		if !ok {
+			if len(links) > 0 {
+				break
+			}
+			return nil, errors.New("unexpected history response")
+		}
+
+		msgs := modified.GetMessages()
+		if len(msgs) == 0 {
+			break
+		}
+
+		minID := 0
+		for _, m := range msgs { // newest first
+			if id := m.GetID(); id > 0 && (minID == 0 || id < minID) {
+				minID = id
+			}
+			scanned++
+			msg, ok := m.(*tg.Message)
+			if !ok {
 				continue
 			}
-			seen[l] = struct{}{}
-			links = append(links, l)
-			if maxProxies > 0 && len(links) >= maxProxies {
-				return links, nil
+			for _, l := range extractProxyLinksFromMessage(msg) {
+				if _, dup := seen[l]; dup {
+					continue
+				}
+				seen[l] = struct{}{}
+				links = append(links, l)
+				if maxProxies > 0 && len(links) >= maxProxies {
+					return links, nil
+				}
 			}
 		}
+
+		if len(msgs) < historyPageSize || minID == 0 {
+			break // reached the start of the channel
+		}
+		offsetID = minID // next page: messages older than the oldest in this batch
 	}
 	return links, nil
 }
@@ -603,9 +631,11 @@ type FetchTGRequest struct {
 // fetchChannelsViaTelegram opens one authenticated client (through the given
 // MTProto proxy) and pulls proxy links from each channel's recent history.
 func fetchChannelsViaTelegram(ctx context.Context, req FetchTGRequest) (FetchChannelsResponse, error) {
+	// perChannel is the max proxies taken from each channel; <= 0 means "all"
+	// (bounded by the message-scan safety cap), > perChannelMax is clamped.
 	perChannel := req.Limit
-	if perChannel <= 0 {
-		perChannel = perChannelDefault
+	if perChannel < 0 {
+		perChannel = 0
 	}
 	if perChannel > perChannelMax {
 		perChannel = perChannelMax

--- a/tgfetch.go
+++ b/tgfetch.go
@@ -1,0 +1,690 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/telegram/auth"
+	"github.com/gotd/td/telegram/dcs"
+	"github.com/gotd/td/session"
+	"github.com/gotd/td/tg"
+	"github.com/gotd/td/tgerr"
+)
+
+// ----------------------------------------------------------------------------
+// Secure local storage for Telegram user credentials.
+//
+// The session (auth keys that grant access to the user account) and the
+// api_id/api_hash are stored ONLY under the OS user-config directory
+// (e.g. ~/.config/mtproto-checker on Linux), which lives entirely outside the
+// project tree — it can never be committed to git. Files are created with 0600
+// and the directory with 0700 so only the owning user can read them.
+// ----------------------------------------------------------------------------
+
+const (
+	perChannelDefault   = 10  // proxies taken per channel when unspecified
+	perChannelMax       = 100 // hard cap on proxies taken per channel
+	historyScanMessages = 100 // recent messages scanned to fill the quota
+	tgFetchTimeout      = 90 * time.Second
+)
+
+// tgConfigDir returns the per-user directory holding the session and app
+// credentials, creating it with owner-only permissions if needed.
+func tgConfigDir() (string, error) {
+	base, err := os.UserConfigDir()
+	if err != nil {
+		// Fall back to the home directory if UserConfigDir is unavailable.
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			return "", errors.Wrap(err, "locate user config dir")
+		}
+		base = filepath.Join(home, ".config")
+	}
+	dir := filepath.Join(base, "mtproto-checker")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", errors.Wrap(err, "create config dir")
+	}
+	// Tighten perms in case the dir already existed with looser bits.
+	_ = os.Chmod(dir, 0o700)
+	return dir, nil
+}
+
+func sessionFilePath() (string, error) {
+	dir, err := tgConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "session.json"), nil
+}
+
+func appConfigPath() (string, error) {
+	dir, err := tgConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "app.json"), nil
+}
+
+type tgAppConfig struct {
+	AppID   int    `json:"app_id"`
+	AppHash string `json:"app_hash"`
+}
+
+// loadAppCreds resolves the api_id/api_hash to use. Priority:
+//  1. TG_APP_ID + TG_APP_HASH environment variables
+//  2. the locally saved app.json
+//  3. the built-in public test credentials (fallback)
+func loadAppCreds() (int, string) {
+	if idStr := os.Getenv("TG_APP_ID"); idStr != "" {
+		if hash := os.Getenv("TG_APP_HASH"); hash != "" {
+			if id, err := strconv.Atoi(idStr); err == nil {
+				return id, hash
+			}
+		}
+	}
+	if path, err := appConfigPath(); err == nil {
+		if data, err := os.ReadFile(path); err == nil {
+			var cfg tgAppConfig
+			if json.Unmarshal(data, &cfg) == nil && cfg.AppID != 0 && cfg.AppHash != "" {
+				return cfg.AppID, cfg.AppHash
+			}
+		}
+	}
+	return testAppID, testAppHash
+}
+
+func saveAppCreds(id int, hash string) error {
+	path, err := appConfigPath()
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(tgAppConfig{AppID: id, AppHash: hash})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// ----------------------------------------------------------------------------
+// MTProxy transport shared by check / login / fetch.
+// ----------------------------------------------------------------------------
+
+// buildMTProxyResolver creates a gotd DC resolver that tunnels through an
+// MTProto proxy. Empty server falls back to the default (direct) resolver.
+func buildMTProxyResolver(server string, port int, secret string) (dcs.Resolver, error) {
+	if server == "" || port == 0 || secret == "" {
+		return nil, errors.New("a working MTProto proxy (server, port, secret) is required")
+	}
+	addr := net.JoinHostPort(server, fmt.Sprintf("%d", port))
+	decodedSecret, err := decodeSecret(secret)
+	if err != nil {
+		return nil, errors.Wrap(err, "decode secret")
+	}
+	resolver, err := dcs.MTProxy(addr, decodedSecret, dcs.MTProxyOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "create MTProxy resolver")
+	}
+	return resolver, nil
+}
+
+func newSessionStorage() (session.Storage, error) {
+	path, err := sessionFilePath()
+	if err != nil {
+		return nil, err
+	}
+	return &session.FileStorage{Path: path}, nil
+}
+
+// ----------------------------------------------------------------------------
+// Login manager: bridges the blocking gotd auth flow to stateless HTTP calls.
+// ----------------------------------------------------------------------------
+
+type ProxyCreds struct {
+	Server string `json:"server"`
+	Port   int    `json:"port"`
+	Secret string `json:"secret"`
+}
+
+type loginManager struct {
+	mu        sync.Mutex
+	state     string // idle, starting, awaiting_captcha, awaiting_code, awaiting_password, authorized, failed
+	errMsg    string
+	phone     string
+	sitekey   string // reCAPTCHA site key, set when state == awaiting_captcha
+	codeCh    chan string
+	pwdCh     chan string
+	captchaCh chan string
+	cancel    context.CancelFunc
+}
+
+var loginMgr = &loginManager{state: "idle"}
+
+func (m *loginManager) snapshot() (state, errMsg, phone, sitekey string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.state, m.errMsg, m.phone, m.sitekey
+}
+
+func (m *loginManager) setState(state string) {
+	m.mu.Lock()
+	m.state = state
+	m.mu.Unlock()
+}
+
+func (m *loginManager) fail(err error) {
+	m.mu.Lock()
+	m.state = "failed"
+	m.errMsg = err.Error()
+	m.mu.Unlock()
+}
+
+// recaptchaSitekey extracts the reCAPTCHA site key from a Telegram
+// RECAPTCHA_CHECK error. Telegram returns these as
+// "RECAPTCHA_CHECK_<purpose>__<sitekey>" (e.g. the purpose is "signup" or
+// "login"); the site key is everything after the final "__".
+func recaptchaSitekey(err error) (string, bool) {
+	rpcErr, ok := tgerr.As(err)
+	if !ok {
+		return "", false
+	}
+	idx := strings.Index(rpcErr.Message, "RECAPTCHA_CHECK")
+	if idx < 0 {
+		return "", false
+	}
+	parts := strings.SplitN(rpcErr.Message[idx:], "__", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return "", false
+	}
+	return parts[1], true
+}
+
+// start kicks off a login. It returns immediately; progress is observed via
+// snapshot() / the /tg/login/status endpoint.
+func (m *loginManager) start(creds ProxyCreds, phone string, appID int, appHash string) error {
+	m.mu.Lock()
+	switch m.state {
+	case "starting", "awaiting_captcha", "awaiting_code", "awaiting_password":
+		m.mu.Unlock()
+		return errors.New("a login is already in progress")
+	}
+	m.state = "starting"
+	m.errMsg = ""
+	m.phone = phone
+	m.sitekey = ""
+	m.codeCh = make(chan string, 1)
+	m.pwdCh = make(chan string, 1)
+	m.captchaCh = make(chan string, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	m.mu.Unlock()
+
+	resolver, err := buildMTProxyResolver(creds.Server, creds.Port, creds.Secret)
+	if err != nil {
+		cancel()
+		m.fail(err)
+		return err
+	}
+	storage, err := newSessionStorage()
+	if err != nil {
+		cancel()
+		m.fail(err)
+		return err
+	}
+
+	client := telegram.NewClient(appID, appHash, telegram.Options{
+		Resolver:       resolver,
+		SessionStorage: storage,
+		Device:         telegram.DeviceTDesktopWindows(),
+		NoUpdates:      true,
+	})
+
+	go func() {
+		defer cancel()
+		runErr := client.Run(ctx, func(ctx context.Context) error {
+			return m.runAuth(ctx, client, phone, appID, appHash)
+		})
+		if runErr != nil {
+			m.fail(runErr)
+			return
+		}
+		m.setState("authorized")
+	}()
+	return nil
+}
+
+// runAuth drives the user authentication flow manually so that a reCAPTCHA
+// challenge on send-code can be surfaced to the UI and retried with the solved
+// token (via invokeWithReCaptcha). The rest of the flow (code, optional 2FA
+// password) does not require a captcha.
+func (m *loginManager) runAuth(ctx context.Context, client *telegram.Client, phone string, appID int, appHash string) error {
+	authClient := client.Auth()
+
+	sent, err := authClient.SendCode(ctx, phone, auth.SendCodeOptions{})
+	if err != nil {
+		sitekey, ok := recaptchaSitekey(err)
+		if !ok {
+			return err
+		}
+		// Surface the site key and wait for the browser-solved token.
+		m.mu.Lock()
+		m.sitekey = sitekey
+		m.state = "awaiting_captcha"
+		m.mu.Unlock()
+
+		var token string
+		select {
+		case token = <-m.captchaCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		// Retry the exact same send-code request, wrapped with the token.
+		req := &tg.AuthSendCodeRequest{
+			PhoneNumber: phone,
+			APIID:       appID,
+			APIHash:     appHash,
+			Settings:    tg.CodeSettings{},
+		}
+		var box tg.AuthSentCodeBox
+		if err := client.Invoke(ctx, &tg.InvokeWithReCaptchaRequest{Token: token, Query: req}, &box); err != nil {
+			return err
+		}
+		sent = box.SentCode
+	}
+
+	sc, ok := sent.(*tg.AuthSentCode)
+	if !ok {
+		return errors.Errorf("unexpected sent code type %T", sent)
+	}
+	codeHash := sc.PhoneCodeHash
+
+	// Await the login code from the UI.
+	m.setState("awaiting_code")
+	var code string
+	select {
+	case code = <-m.codeCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	_, err = authClient.SignIn(ctx, phone, code, codeHash)
+	if errors.Is(err, auth.ErrPasswordAuthNeeded) {
+		// 2FA: await the password from the UI.
+		m.setState("awaiting_password")
+		var pwd string
+		select {
+		case pwd = <-m.pwdCh:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		if pwd == "" {
+			return auth.ErrPasswordNotProvided
+		}
+		if _, err = authClient.Password(ctx, pwd); err != nil {
+			return err
+		}
+		return nil
+	}
+	return err
+}
+
+func (m *loginManager) submitCaptcha(token string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.state != "awaiting_captcha" {
+		return errors.Errorf("not awaiting a captcha (state: %s)", m.state)
+	}
+	select {
+	case m.captchaCh <- token:
+		return nil
+	default:
+		return errors.New("captcha already submitted")
+	}
+}
+
+func (m *loginManager) submitCode(code string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.state != "awaiting_code" {
+		return errors.Errorf("not awaiting a code (state: %s)", m.state)
+	}
+	select {
+	case m.codeCh <- code:
+		return nil
+	default:
+		return errors.New("code already submitted")
+	}
+}
+
+func (m *loginManager) submitPassword(pwd string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.state != "awaiting_password" {
+		return errors.Errorf("not awaiting a password (state: %s)", m.state)
+	}
+	select {
+	case m.pwdCh <- pwd:
+		return nil
+	default:
+		return errors.New("password already submitted")
+	}
+}
+
+// isAuthorized opens a short-lived client to verify the stored session is
+// still valid and authorized.
+func isAuthorized(ctx context.Context, creds ProxyCreds) (bool, error) {
+	resolver, err := buildMTProxyResolver(creds.Server, creds.Port, creds.Secret)
+	if err != nil {
+		return false, err
+	}
+	storage, err := newSessionStorage()
+	if err != nil {
+		return false, err
+	}
+	appID, appHash := loadAppCreds()
+	client := telegram.NewClient(appID, appHash, telegram.Options{
+		Resolver:       resolver,
+		SessionStorage: storage,
+		Device:         telegram.DeviceTDesktopWindows(),
+		NoUpdates:      true,
+	})
+
+	var authorized bool
+	runErr := client.Run(ctx, func(ctx context.Context) error {
+		st, err := client.Auth().Status(ctx)
+		if err != nil {
+			return err
+		}
+		authorized = st.Authorized
+		return nil
+	})
+	if runErr != nil {
+		return false, runErr
+	}
+	return authorized, nil
+}
+
+// logout deletes the stored session so the account can no longer be accessed.
+func logout() error {
+	path, err := sessionFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	loginMgr.mu.Lock()
+	loginMgr.state = "idle"
+	loginMgr.errMsg = ""
+	loginMgr.phone = ""
+	loginMgr.sitekey = ""
+	loginMgr.mu.Unlock()
+	return nil
+}
+
+// ----------------------------------------------------------------------------
+// Fetching channel proxy links via the authenticated MTProto client.
+// ----------------------------------------------------------------------------
+
+// Channels post proxies in wildly different shapes. We recognise two:
+//
+//  1. A full link — tg://proxy?... or https://t.me/proxy?... — usually with
+//     markdown/emoji/Persian text crammed right after the secret.
+//  2. A label block — "Server: / Port: / Secret:" — sometimes dressed up with
+//     small-capital unicode letters (sᴇʀᴠᴇʀ ›) and "Unknown" hostnames.
+//
+// Both are normalised to a canonical tg://proxy?server=&port=&secret= link so
+// duplicates collapse regardless of the original formatting.
+var (
+	// proxyURLRe captures the three params of a proxy link. The secret group
+	// stops at the first character that cannot belong to a hex/base64 secret,
+	// which trims the trailing ")__", "**", ")پروکسی", emoji, etc.
+	proxyURLRe = regexp.MustCompile(`(?i)(?:tg://|https?://t\.me/)proxy\?server=([^&\s"'<>]+)&port=(\d+)&secret=([A-Za-z0-9_+/=-]+)`)
+
+	// proxyLabeledRe captures a "Server/Port/Secret" block (separator ":" or
+	// "›", values on the same or following lines).
+	proxyLabeledRe = regexp.MustCompile(`(?is)server\s*[:›]?\s*([A-Za-z0-9._-]+).*?port\s*[:›]?\s*(\d+).*?secret\s*[:›]?\s*([A-Za-z0-9_+/=-]+)`)
+
+	// labelNormalizer maps the small-capital unicode letters channels use to
+	// dress up the Server/Port/Secret labels back to ASCII, and drops
+	// zero-width marks, so proxyLabeledRe can read them.
+	labelNormalizer = strings.NewReplacer(
+		"ᴀ", "a", "ʙ", "b", "ᴄ", "c", "ᴅ", "d", "ᴇ", "e",
+		"ᴊ", "j", "ᴋ", "k", "ʟ", "l", "ᴍ", "m", "ɴ", "n",
+		"ᴏ", "o", "ᴘ", "p", "ʀ", "r", "ᴛ", "t", "ᴜ", "u",
+		"ᴠ", "v", "ɪ", "i",
+		"\u200b", "", "\u200e", "", "\u200f", "", "\ufeff", "",
+	)
+)
+
+// buildProxyLink validates the parts and renders a canonical proxy link, or
+// reports false for junk (missing/"unknown" host, out-of-range port, stub
+// secret).
+func buildProxyLink(server, port, secret string) (string, bool) {
+	server = strings.TrimRight(strings.TrimSpace(server), ".")
+	if server == "" || strings.EqualFold(server, "unknown") {
+		return "", false
+	}
+	p, err := strconv.Atoi(port)
+	if err != nil || p < 1 || p > 65535 {
+		return "", false
+	}
+	if len(secret) < 8 {
+		return "", false
+	}
+	return fmt.Sprintf("tg://proxy?server=%s&port=%d&secret=%s", server, p, secret), true
+}
+
+// collectProxyLinks appends canonical proxy links found in text (both URL and
+// labeled forms) to out, skipping anything already in seen.
+func collectProxyLinks(text string, seen map[string]struct{}, out []string) []string {
+	add := func(server, port, secret string) []string {
+		link, ok := buildProxyLink(server, port, secret)
+		if !ok {
+			return out
+		}
+		if _, dup := seen[link]; dup {
+			return out
+		}
+		seen[link] = struct{}{}
+		return append(out, link)
+	}
+
+	text = html.UnescapeString(text)
+	for _, m := range proxyURLRe.FindAllStringSubmatch(text, -1) {
+		out = add(m[1], m[2], m[3])
+	}
+	for _, m := range proxyLabeledRe.FindAllStringSubmatch(labelNormalizer.Replace(text), -1) {
+		out = add(m[1], m[2], m[3])
+	}
+	return out
+}
+
+// extractProxyLinksFromText is the testable core: all unique proxy links in a
+// single blob of text.
+func extractProxyLinksFromText(text string) []string {
+	return collectProxyLinks(text, make(map[string]struct{}), nil)
+}
+
+// extractProxyLinksFromMessage scans the raw message text and any text-URL
+// entities (proxy links are often hidden behind formatted/button links where
+// the visible text differs from the underlying URL).
+func extractProxyLinksFromMessage(msg *tg.Message) []string {
+	seen := make(map[string]struct{})
+	out := collectProxyLinks(msg.Message, seen, nil)
+	for _, e := range msg.Entities {
+		if tu, ok := e.(*tg.MessageEntityTextURL); ok {
+			out = collectProxyLinks(tu.URL, seen, out)
+		}
+	}
+	return out
+}
+
+// fetchChannelViaTG returns up to maxProxies proxy links from a channel,
+// taking the most recent ones first (Telegram history is newest-first). It
+// scans message history until the quota is filled or the messages run out.
+func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxProxies int) ([]string, error) {
+	resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: channel})
+	if err != nil {
+		return nil, errors.Wrap(err, "resolve username")
+	}
+
+	var peer tg.InputPeerClass
+	for _, c := range resolved.Chats {
+		if ch, ok := c.(*tg.Channel); ok {
+			peer = &tg.InputPeerChannel{ChannelID: ch.ID, AccessHash: ch.AccessHash}
+			break
+		}
+	}
+	if peer == nil {
+		// Could be a basic group or a user — fall back to chat if present.
+		for _, c := range resolved.Chats {
+			if chat, ok := c.(*tg.Chat); ok {
+				peer = &tg.InputPeerChat{ChatID: chat.ID}
+				break
+			}
+		}
+	}
+	if peer == nil {
+		return nil, errors.New("not a channel/group, or no access")
+	}
+
+	hist, err := api.MessagesGetHistory(ctx, &tg.MessagesGetHistoryRequest{
+		Peer:  peer,
+		Limit: historyScanMessages,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "get history")
+	}
+	modified, ok := hist.AsModified()
+	if !ok {
+		return nil, errors.New("unexpected history response")
+	}
+
+	var links []string
+	seen := make(map[string]struct{})
+	for _, m := range modified.GetMessages() { // newest first
+		msg, ok := m.(*tg.Message)
+		if !ok {
+			continue
+		}
+		for _, l := range extractProxyLinksFromMessage(msg) {
+			if _, dup := seen[l]; dup {
+				continue
+			}
+			seen[l] = struct{}{}
+			links = append(links, l)
+			if maxProxies > 0 && len(links) >= maxProxies {
+				return links, nil
+			}
+		}
+	}
+	return links, nil
+}
+
+type FetchTGRequest struct {
+	Channels []string   `json:"channels"`
+	Proxy    ProxyCreds `json:"proxy"`
+	Limit    int        `json:"limit,omitempty"`
+}
+
+// fetchChannelsViaTelegram opens one authenticated client (through the given
+// MTProto proxy) and pulls proxy links from each channel's recent history.
+func fetchChannelsViaTelegram(ctx context.Context, req FetchTGRequest) (FetchChannelsResponse, error) {
+	perChannel := req.Limit
+	if perChannel <= 0 {
+		perChannel = perChannelDefault
+	}
+	if perChannel > perChannelMax {
+		perChannel = perChannelMax
+	}
+
+	// Normalize + dedupe channel names (reuses the existing helper).
+	seenCh := make(map[string]struct{})
+	var channels []string
+	for _, c := range req.Channels {
+		name := normalizeChannel(c)
+		if name == "" {
+			continue
+		}
+		if _, ok := seenCh[name]; ok {
+			continue
+		}
+		seenCh[name] = struct{}{}
+		channels = append(channels, name)
+		if len(channels) >= maxChannels {
+			break
+		}
+	}
+	if len(channels) == 0 {
+		return FetchChannelsResponse{}, errors.New("no valid channels provided")
+	}
+
+	resolver, err := buildMTProxyResolver(req.Proxy.Server, req.Proxy.Port, req.Proxy.Secret)
+	if err != nil {
+		return FetchChannelsResponse{}, err
+	}
+	storage, err := newSessionStorage()
+	if err != nil {
+		return FetchChannelsResponse{}, err
+	}
+	appID, appHash := loadAppCreds()
+	client := telegram.NewClient(appID, appHash, telegram.Options{
+		Resolver:       resolver,
+		SessionStorage: storage,
+		Device:         telegram.DeviceTDesktopWindows(),
+		NoUpdates:      true,
+	})
+
+	runCtx, cancel := context.WithTimeout(ctx, tgFetchTimeout)
+	defer cancel()
+
+	var resp FetchChannelsResponse
+	seenLink := make(map[string]struct{})
+
+	runErr := client.Run(runCtx, func(ctx context.Context) error {
+		st, err := client.Auth().Status(ctx)
+		if err != nil {
+			return errors.Wrap(err, "auth status")
+		}
+		if !st.Authorized {
+			return errors.New("not logged in — complete Telegram login first")
+		}
+
+		api := client.API()
+		for _, ch := range channels {
+			// Telegram rate-limits resolve/getHistory; small gap between channels.
+			links, err := fetchChannelViaTG(ctx, api, ch, perChannel)
+			if err != nil {
+				resp.Errors = append(resp.Errors, fmt.Sprintf("%s: %v", ch, err))
+				continue
+			}
+			for _, l := range links {
+				if _, ok := seenLink[l]; ok {
+					continue
+				}
+				seenLink[l] = struct{}{}
+				resp.Links = append(resp.Links, l)
+			}
+		}
+		return nil
+	})
+	if runErr != nil {
+		return FetchChannelsResponse{}, runErr
+	}
+
+	resp.Count = len(resp.Links)
+	return resp, nil
+}

--- a/tgfetch.go
+++ b/tgfetch.go
@@ -36,8 +36,8 @@ import (
 const (
 	perChannelMax   = 1000 // hard cap on proxies taken per channel
 	historyPageSize = 100  // Telegram's max messages per getHistory call
-	maxScanMessages = 1500 // safety cap on messages paged through per channel
-	tgFetchTimeout  = 120 * time.Second
+	maxScanMessages = 3000 // safety cap on messages paged through per channel
+	tgFetchTimeout  = 180 * time.Second
 )
 
 // tgConfigDir returns the per-user directory holding the session and app
@@ -562,14 +562,48 @@ func extractProxyLinksFromMessage(msg *tg.Message) []string {
 	return out
 }
 
+// channelStats reports how a channel scan went, for surfacing to the user.
+type channelStats struct {
+	found   int
+	scanned int
+	stop    string // quota | end | scan-cap | flood | error
+}
+
+// getHistoryFloodWait calls MessagesGetHistory, transparently waiting out
+// FLOOD_WAIT (RPC 420) responses up to a few times so deep pagination isn't
+// aborted by Telegram's rate limiter.
+func getHistoryFloodWait(ctx context.Context, api *tg.Client, req *tg.MessagesGetHistoryRequest) (tg.MessagesMessagesClass, error) {
+	for attempt := 0; attempt < 4; attempt++ {
+		hist, err := api.MessagesGetHistory(ctx, req)
+		if err == nil {
+			return hist, nil
+		}
+		rpcErr, ok := tgerr.As(err)
+		if !ok || !rpcErr.IsCode(420) {
+			return nil, err
+		}
+		wait := time.Duration(rpcErr.Argument)*time.Second + time.Second
+		if wait > 45*time.Second {
+			wait = 45 * time.Second
+		}
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return nil, errors.New("FLOOD_WAIT: retries exhausted")
+}
+
 // fetchChannelViaTG returns up to maxProxies proxy links from a channel,
 // newest first (maxProxies <= 0 means "as many as possible"). Telegram caps a
 // single getHistory to 100 messages, so we page backwards with OffsetID until
 // the quota is filled, the channel runs out, or the scan safety cap is hit.
-func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxProxies int) ([]string, error) {
+func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxProxies int) ([]string, channelStats, error) {
+	var stats channelStats
 	resolved, err := api.ContactsResolveUsername(ctx, &tg.ContactsResolveUsernameRequest{Username: channel})
 	if err != nil {
-		return nil, errors.Wrap(err, "resolve username")
+		return nil, stats, errors.Wrap(err, "resolve username")
 	}
 
 	var peer tg.InputPeerClass
@@ -589,36 +623,39 @@ func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxP
 		}
 	}
 	if peer == nil {
-		return nil, errors.New("not a channel/group, or no access")
+		return nil, stats, errors.New("not a channel/group, or no access")
 	}
 
 	var links []string
 	seen := make(map[string]struct{})
 	offsetID := 0
-	scanned := 0
+	stats.stop = "scan-cap"
 
-	for scanned < maxScanMessages {
-		hist, err := api.MessagesGetHistory(ctx, &tg.MessagesGetHistoryRequest{
+	for stats.scanned < maxScanMessages {
+		hist, err := getHistoryFloodWait(ctx, api, &tg.MessagesGetHistoryRequest{
 			Peer:     peer,
 			Limit:    historyPageSize,
 			OffsetID: offsetID,
 		})
 		if err != nil {
 			if len(links) > 0 {
+				stats.stop = "flood/error: " + err.Error()
 				break // keep what we already gathered instead of failing the channel
 			}
-			return nil, errors.Wrap(err, "get history")
+			return nil, stats, errors.Wrap(err, "get history")
 		}
 		modified, ok := hist.AsModified()
 		if !ok {
 			if len(links) > 0 {
+				stats.stop = "non-modified history"
 				break
 			}
-			return nil, errors.New("unexpected history response")
+			return nil, stats, errors.New("unexpected history response")
 		}
 
 		msgs := modified.GetMessages()
 		if len(msgs) == 0 {
+			stats.stop = "end"
 			break
 		}
 
@@ -627,7 +664,7 @@ func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxP
 			if id := m.GetID(); id > 0 && (minID == 0 || id < minID) {
 				minID = id
 			}
-			scanned++
+			stats.scanned++
 			msg, ok := m.(*tg.Message)
 			if !ok {
 				continue
@@ -639,17 +676,21 @@ func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxP
 				seen[l] = struct{}{}
 				links = append(links, l)
 				if maxProxies > 0 && len(links) >= maxProxies {
-					return links, nil
+					stats.found = len(links)
+					stats.stop = "quota"
+					return links, stats, nil
 				}
 			}
 		}
 
 		if len(msgs) < historyPageSize || minID == 0 {
+			stats.stop = "end"
 			break // reached the start of the channel
 		}
 		offsetID = minID // next page: messages older than the oldest in this batch
 	}
-	return links, nil
+	stats.found = len(links)
+	return links, stats, nil
 }
 
 type FetchTGRequest struct {
@@ -725,19 +766,25 @@ func fetchChannelsViaTelegram(ctx context.Context, req FetchTGRequest) (FetchCha
 
 		api := client.API()
 		for _, ch := range channels {
-			// Telegram rate-limits resolve/getHistory; small gap between channels.
-			links, err := fetchChannelViaTG(ctx, api, ch, perChannel)
+			links, stats, err := fetchChannelViaTG(ctx, api, ch, perChannel)
 			if err != nil {
 				resp.Errors = append(resp.Errors, fmt.Sprintf("%s: %v", ch, err))
 				continue
 			}
+			added := 0
 			for _, l := range links {
 				if _, ok := seenLink[l]; ok {
 					continue
 				}
 				seenLink[l] = struct{}{}
 				resp.Links = append(resp.Links, l)
+				added++
 			}
+			// Per-channel diagnostics so the user can see the real bottleneck
+			// (e.g. ran out of messages vs. hit the scan cap vs. flood wait).
+			resp.Notes = append(resp.Notes, fmt.Sprintf(
+				"%s: %d new (%d found in %d msgs scanned, stop=%s)",
+				ch, added, stats.found, stats.scanned, stats.stop))
 		}
 		return nil
 	})

--- a/tgfetch.go
+++ b/tgfetch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,10 +16,11 @@ import (
 	"time"
 
 	"github.com/go-faster/errors"
+	"github.com/gotd/td/session"
 	"github.com/gotd/td/telegram"
 	"github.com/gotd/td/telegram/auth"
 	"github.com/gotd/td/telegram/dcs"
-	"github.com/gotd/td/session"
+	"github.com/gotd/td/telegram/downloader"
 	"github.com/gotd/td/tg"
 	"github.com/gotd/td/tgerr"
 )
@@ -34,10 +36,12 @@ import (
 // ----------------------------------------------------------------------------
 
 const (
-	perChannelMax   = 1000 // hard cap on proxies taken per channel
-	historyPageSize = 100  // Telegram's max messages per getHistory call
-	maxScanMessages = 3000 // safety cap on messages paged through per channel
-	tgFetchTimeout  = 180 * time.Second
+	perChannelMax     = 1000    // hard cap on proxies taken per channel
+	historyPageSize   = 100     // Telegram's max messages per getHistory call
+	maxScanMessages   = 3000    // safety cap on messages paged through per channel
+	maxDocsPerChannel = 30      // text attachments downloaded+parsed per channel
+	maxDocBytes       = 4 << 20 // skip attachments larger than 4 MiB
+	tgFetchTimeout    = 180 * time.Second
 )
 
 // tgConfigDir returns the per-user directory holding the session and app
@@ -595,6 +599,53 @@ func getHistoryFloodWait(ctx context.Context, api *tg.Client, req *tg.MessagesGe
 	return nil, errors.New("FLOOD_WAIT: retries exhausted")
 }
 
+// downloadTextDocument returns the text of a small text/plain (or *.txt)
+// attachment on the message, if any, so proxy lists posted as files are not
+// missed. Returns false for non-text, oversized, or undownloadable media.
+func downloadTextDocument(ctx context.Context, api *tg.Client, msg *tg.Message) (string, bool) {
+	media, ok := msg.GetMedia()
+	if !ok {
+		return "", false
+	}
+	md, ok := media.(*tg.MessageMediaDocument)
+	if !ok {
+		return "", false
+	}
+	docClass, ok := md.GetDocument()
+	if !ok {
+		return "", false
+	}
+	doc, ok := docClass.(*tg.Document)
+	if !ok || doc.Size > maxDocBytes {
+		return "", false
+	}
+
+	isText := strings.HasPrefix(doc.MimeType, "text/")
+	if !isText {
+		for _, a := range doc.Attributes {
+			if fn, ok := a.(*tg.DocumentAttributeFilename); ok {
+				if strings.HasSuffix(strings.ToLower(fn.FileName), ".txt") {
+					isText = true
+				}
+			}
+		}
+	}
+	if !isText {
+		return "", false
+	}
+
+	loc := &tg.InputDocumentFileLocation{
+		ID:            doc.ID,
+		AccessHash:    doc.AccessHash,
+		FileReference: doc.FileReference,
+	}
+	var buf bytes.Buffer
+	if _, err := downloader.NewDownloader().Download(api, loc).Stream(ctx, &buf); err != nil {
+		return "", false
+	}
+	return buf.String(), true
+}
+
 // fetchChannelViaTG returns up to maxProxies proxy links from a channel,
 // newest first (maxProxies <= 0 means "as many as possible"). Telegram caps a
 // single getHistory to 100 messages, so we page backwards with OffsetID until
@@ -629,7 +680,18 @@ func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxP
 	var links []string
 	seen := make(map[string]struct{})
 	offsetID := 0
+	docsDownloaded := 0
 	stats.stop = "scan-cap"
+
+	// addLink records a unique proxy; returns true once the quota is reached.
+	addLink := func(l string) bool {
+		if _, dup := seen[l]; dup {
+			return false
+		}
+		seen[l] = struct{}{}
+		links = append(links, l)
+		return maxProxies > 0 && len(links) >= maxProxies
+	}
 
 	for stats.scanned < maxScanMessages {
 		hist, err := getHistoryFloodWait(ctx, api, &tg.MessagesGetHistoryRequest{
@@ -670,15 +732,24 @@ func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxP
 				continue
 			}
 			for _, l := range extractProxyLinksFromMessage(msg) {
-				if _, dup := seen[l]; dup {
-					continue
-				}
-				seen[l] = struct{}{}
-				links = append(links, l)
-				if maxProxies > 0 && len(links) >= maxProxies {
+				if addLink(l) {
 					stats.found = len(links)
 					stats.stop = "quota"
 					return links, stats, nil
+				}
+			}
+			// Some channels drop a .txt list as a file attachment; download and
+			// parse it too (bounded per channel to keep fetches fast).
+			if docsDownloaded < maxDocsPerChannel {
+				if text, ok := downloadTextDocument(ctx, api, msg); ok {
+					docsDownloaded++
+					for _, l := range extractProxyLinksFromText(text) {
+						if addLink(l) {
+							stats.found = len(links)
+							stats.stop = "quota"
+							return links, stats, nil
+						}
+					}
 				}
 			}
 		}

--- a/tgfetch.go
+++ b/tgfetch.go
@@ -38,10 +38,10 @@ import (
 const (
 	perChannelMax     = 1000    // hard cap on proxies taken per channel
 	historyPageSize   = 100     // Telegram's max messages per getHistory call
-	maxScanMessages   = 3000    // safety cap on messages paged through per channel
+	maxScanMessages   = 15000   // safety cap on messages paged through per channel
 	maxDocsPerChannel = 30      // text attachments downloaded+parsed per channel
 	maxDocBytes       = 4 << 20 // skip attachments larger than 4 MiB
-	tgFetchTimeout    = 180 * time.Second
+	tgFetchTimeout    = 280 * time.Second
 )
 
 // tgConfigDir returns the per-user directory holding the session and app
@@ -568,9 +568,10 @@ func extractProxyLinksFromMessage(msg *tg.Message) []string {
 
 // channelStats reports how a channel scan went, for surfacing to the user.
 type channelStats struct {
-	found   int
-	scanned int
-	stop    string // quota | end | scan-cap | flood | error
+	found     int
+	scanned   int
+	withProxy int    // messages that carried at least one proxy link
+	stop      string // quota | end | scan-cap | flood | error
 }
 
 // getHistoryFloodWait calls MessagesGetHistory, transparently waiting out
@@ -731,11 +732,14 @@ func fetchChannelViaTG(ctx context.Context, api *tg.Client, channel string, maxP
 			if !ok {
 				continue
 			}
-			for _, l := range extractProxyLinksFromMessage(msg) {
-				if addLink(l) {
-					stats.found = len(links)
-					stats.stop = "quota"
-					return links, stats, nil
+			if msgLinks := extractProxyLinksFromMessage(msg); len(msgLinks) > 0 {
+				stats.withProxy++
+				for _, l := range msgLinks {
+					if addLink(l) {
+						stats.found = len(links)
+						stats.stop = "quota"
+						return links, stats, nil
+					}
 				}
 			}
 			// Some channels drop a .txt list as a file attachment; download and
@@ -854,8 +858,8 @@ func fetchChannelsViaTelegram(ctx context.Context, req FetchTGRequest) (FetchCha
 			// Per-channel diagnostics so the user can see the real bottleneck
 			// (e.g. ran out of messages vs. hit the scan cap vs. flood wait).
 			resp.Notes = append(resp.Notes, fmt.Sprintf(
-				"%s: %d new (%d found in %d msgs scanned, stop=%s)",
-				ch, added, stats.found, stats.scanned, stats.stop))
+				"%s: %d new | %d unique found | %d/%d msgs had a proxy | stop=%s",
+				ch, added, stats.found, stats.withProxy, stats.scanned, stats.stop))
 		}
 		return nil
 	})

--- a/tgfetch.go
+++ b/tgfetch.go
@@ -518,17 +518,47 @@ func extractProxyLinksFromText(text string) []string {
 	return collectProxyLinks(text, make(map[string]struct{}), nil)
 }
 
-// extractProxyLinksFromMessage scans the raw message text and any text-URL
-// entities (proxy links are often hidden behind formatted/button links where
-// the visible text differs from the underlying URL).
+// extractProxyLinksFromMessage scans every place a channel can stash a proxy
+// link: the raw text, formatted hyperlinks (text-URL entities), inline glass
+// buttons (reply markup), and the attached link/webpage preview.
 func extractProxyLinksFromMessage(msg *tg.Message) []string {
 	seen := make(map[string]struct{})
 	out := collectProxyLinks(msg.Message, seen, nil)
+
+	// Hyperlinks where the visible text differs from the underlying URL.
 	for _, e := range msg.Entities {
 		if tu, ok := e.(*tg.MessageEntityTextURL); ok {
 			out = collectProxyLinks(tu.URL, seen, out)
 		}
 	}
+
+	// Inline keyboard buttons — proxy channels very often hide the link behind
+	// a "Connect" glass button rather than putting it in the message text.
+	if rm, ok := msg.GetReplyMarkup(); ok {
+		if inline, ok := rm.(*tg.ReplyInlineMarkup); ok {
+			for _, row := range inline.Rows {
+				for _, btn := range row.Buttons {
+					switch b := btn.(type) {
+					case *tg.KeyboardButtonURL:
+						out = collectProxyLinks(b.URL, seen, out)
+					case *tg.KeyboardButtonURLAuth:
+						out = collectProxyLinks(b.URL, seen, out)
+					}
+				}
+			}
+		}
+	}
+
+	// Link/webpage preview attached to the message.
+	if media, ok := msg.GetMedia(); ok {
+		if wp, ok := media.(*tg.MessageMediaWebPage); ok {
+			if page, ok := wp.Webpage.(*tg.WebPage); ok {
+				out = collectProxyLinks(page.URL, seen, out)
+				out = collectProxyLinks(page.DisplayURL, seen, out)
+			}
+		}
+	}
+
 	return out
 }
 

--- a/tgfetch_test.go
+++ b/tgfetch_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func contains(links []string, want string) bool {
+	for _, l := range links {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestExtractProxyLinks_URLWithTrailingJunk(t *testing.T) {
+	// Real channel text: links glued to markdown/emoji/Persian junk.
+	text := `پروکسی (https://t.me/proxy?server=65.109.247.142&port=85&secret=FgMBAgABAAH8AxOG4kw63Q) ` +
+		"tg://proxy?server=108.181.123.187&port=8888&secret=7gAA8A8Pd1VV____9QBuLmltZWRpYS5zdGVhbXBvd2VyZWQuY29t)[پروکسی\n" +
+		"tg://proxy?server=195.254.165.216&port=9443&secret=FgMBAgABAAH8AwOG4kw63Q==\n" +
+		"tg://proxy?server=87.248.149.6&port=8443&secret=eeNEgYdJvXrFGRMCIMJdCQ)[پروکسی"
+
+	links := extractProxyLinksFromText(text)
+	want := []string{
+		"tg://proxy?server=65.109.247.142&port=85&secret=FgMBAgABAAH8AxOG4kw63Q",
+		"tg://proxy?server=108.181.123.187&port=8888&secret=7gAA8A8Pd1VV____9QBuLmltZWRpYS5zdGVhbXBvd2VyZWQuY29t",
+		"tg://proxy?server=195.254.165.216&port=9443&secret=FgMBAgABAAH8AwOG4kw63Q==",
+		"tg://proxy?server=87.248.149.6&port=8443&secret=eeNEgYdJvXrFGRMCIMJdCQ",
+	}
+	for _, w := range want {
+		if !contains(links, w) {
+			t.Errorf("missing %q\n got: %v", w, links)
+		}
+	}
+	// No junk should leak into any secret.
+	for _, l := range links {
+		if strings.ContainsAny(l, ")[*پروکسی ") {
+			t.Errorf("junk leaked into link: %q", l)
+		}
+	}
+}
+
+func TestExtractProxyLinks_LabeledPlain(t *testing.T) {
+	text := `[6/24/26 7:00 PM] Proxy MTProto: Server: 34.51.192.156
+Port: 443
+Secret: dd99c304c8857034be7df934a6e5a95032
+@ProxyMTProto`
+	links := extractProxyLinksFromText(text)
+	want := "tg://proxy?server=34.51.192.156&port=443&secret=dd99c304c8857034be7df934a6e5a95032"
+	if !contains(links, want) {
+		t.Fatalf("labeled-plain not parsed: %v", links)
+	}
+}
+
+func TestExtractProxyLinks_LabeledFancyUnicode(t *testing.T) {
+	// Small-cap labels + a URL that carries the real host (label host is "unknown").
+	text := "🚀ｎｅｗ ｐｒｏｘｙ🚀\n\n🌐sᴇʀᴠᴇʀ › unknown\n🔌 ᴘᴏʀᴛ ›  25565\n" +
+		"🔓‎sᴇᴄʀᴇᴛ › ee104462821249bd7ac519130220c25d0963646e2e79656b74616e65742e636f6d\n\n" +
+		"To SeT :  Connect Proxy (https://t.me/proxy?server=fresh.t-proxy.info.&port=25565&secret=ee104462821249bd7ac519130220c25d0963646e2e79656b74616e65742e636f6d)"
+	links := extractProxyLinksFromText(text)
+	want := "tg://proxy?server=fresh.t-proxy.info&port=25565&secret=ee104462821249bd7ac519130220c25d0963646e2e79656b74616e65742e636f6d"
+	if !contains(links, want) {
+		t.Fatalf("fancy-unicode/URL not parsed: %v", links)
+	}
+	// "unknown" host must never produce a link.
+	for _, l := range links {
+		if strings.Contains(l, "unknown") {
+			t.Errorf("unknown host leaked: %q", l)
+		}
+	}
+}
+
+func TestExtractProxyLinks_DedupesAndDropsJunkPorts(t *testing.T) {
+	text := `tg://proxy?server=1.2.3.4&port=443&secret=dd104462821249bd7ac519130220c25d09
+tg://proxy?server=1.2.3.4&port=443&secret=dd104462821249bd7ac519130220c25d09
+tg://proxy?server=9.9.9.9&port=443000&secret=eeNEgYdJvXrFGRMCIMJdCQ
+tg://proxy?server=8.8.8.8&port=77777&secret=EERighJJvXrFGRMCIMJdCQ
+tg://proxy?server=203.22.241.9&port=80&secret=8080`
+	links := extractProxyLinksFromText(text)
+	if len(links) != 1 {
+		t.Fatalf("expected exactly 1 valid+deduped link, got %d: %v", len(links), links)
+	}
+	if links[0] != "tg://proxy?server=1.2.3.4&port=443&secret=dd104462821249bd7ac519130220c25d09" {
+		t.Errorf("unexpected link: %v", links)
+	}
+}

--- a/tgfetch_test.go
+++ b/tgfetch_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/gotd/td/tg"
 )
 
 func contains(links []string, want string) bool {
@@ -83,5 +85,30 @@ tg://proxy?server=203.22.241.9&port=80&secret=8080`
 	}
 	if links[0] != "tg://proxy?server=1.2.3.4&port=443&secret=dd104462821249bd7ac519130220c25d09" {
 		t.Errorf("unexpected link: %v", links)
+	}
+}
+
+func TestExtractFromMessage_InlineButtonAndWebpage(t *testing.T) {
+	msg := &tg.Message{Message: "🚀 ｎｅｗ ｐｒｏｘｙ 🚀\nServer: unknown"}
+	// Proxy hidden behind a "Connect" glass button (reply markup).
+	msg.SetReplyMarkup(&tg.ReplyInlineMarkup{Rows: []tg.KeyboardButtonRow{{
+		Buttons: []tg.KeyboardButtonClass{
+			&tg.KeyboardButtonURL{Text: "🔗 Connect", URL: "https://t.me/proxy?server=5.75.155.1&port=443&secret=ee1603010200010001fc030386e24c3add626973636f7474692e79656b74616e65742e636f6d"},
+		},
+	}}})
+	// Another proxy in an attached link preview.
+	msg.SetMedia(&tg.MessageMediaWebPage{Webpage: &tg.WebPage{
+		URL: "tg://proxy?server=1.2.3.4&port=85&secret=FgMBAgABAAH8AxOG4kw63Q",
+	}})
+
+	links := extractProxyLinksFromMessage(msg)
+	wants := []string{
+		"tg://proxy?server=5.75.155.1&port=443&secret=ee1603010200010001fc030386e24c3add626973636f7474692e79656b74616e65742e636f6d",
+		"tg://proxy?server=1.2.3.4&port=85&secret=FgMBAgABAAH8AxOG4kw63Q",
+	}
+	for _, w := range wants {
+		if !contains(links, w) {
+			t.Errorf("missing %q\n got: %v", w, links)
+		}
 	}
 }

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GO_BIN="$HOME/go-dist/go/bin/go"
+
+echo "==> Pulling latest changes..."
+cd "$SCRIPT_DIR"
+git pull origin main
+
+echo "==> Rebuilding..."
+"$GO_BIN" build -o mtproto-checker .
+
+echo "==> Done! Run ./mtproto-checker to start."


### PR DESCRIPTION
## Summary

This PR overhauls how MTProto proxies are **fetched from Telegram channels**, making collection far more complete and reliable, while keeping all user credentials **100% local and private**. Proxies are now pulled directly through the authenticated Telegram (MTProto) API tunneled over a working MTProto proxy — no SOCKS5/HTTP web-scraping — so results are accurate even under heavy filtering.

## What's new

### Fetching engine
- **MTProto-only fetching** through the user's Telegram account, tunneled over a healthy MTProto proxy (the unreliable `t.me/s/...` web-scrape path was removed).
- **History pagination** — Telegram caps `getHistory` at 100 messages, so we page backwards with `OffsetID` (up to 15,000 messages/channel) until the requested number of unique proxies is reached or the channel ends. Previously a single channel was silently capped at ~100 messages.
- **FLOOD_WAIT handling** — rate-limit (RPC 420) responses are waited out and retried instead of aborting a scan with partial results.
- **`.txt` attachment parsing** — proxy lists posted as text files are downloaded and parsed (bounded to 30 files / 4 MiB each per channel).
- **Configurable per-channel limit** (`0 = all`, up to 1000), taking the newest proxies first.
- **Per-channel diagnostics** in the UI log (unique found, message density, stop reason) so an empty/spammy channel is distinguishable from a parser gap.

### Parser (handles real-world channel formats)
Every place a channel can hide a link is now scanned and normalized to a canonical `tg://proxy?server=&port=&secret=` form (with de-duplication):
- `tg://proxy` and `https://t.me/proxy` URLs — **trailing markdown/emoji/Persian junk after the secret is trimmed** (e.g. `)__`, `**`, `)پروکسی`).
- Labeled `Server: / Port: / Secret:` blocks, including **small-capital unicode labels** (`🌐sᴇʀᴠᴇʀ ›`) and zero-width marks.
- **Inline glass buttons** (`KeyboardButtonURL` / `URLAuth`) and link/webpage previews.
- Invalid entries (host `unknown`, out-of-range ports, stub secrets) are dropped; obvious **decoy proxies** (over-long or all-`A` padded secrets that never connect) are filtered before checking, with a clear explanation in the log.

### UX & persistence
- Telegram **session resumes automatically** on load (no repeated login).
- The **channel list, MTProto proxy link, and per-channel limit are remembered** across reloads; the channel list is de-duplicated.
- Self-contained binary — `public/` is embedded via `go:embed` (no external files, no CGO).

## Privacy & Security

- **Credentials never leave the machine.** The Telegram session (auth keys) and `api_id`/`api_hash` are stored **only** in the OS user-config directory (`~/.config/mtproto-checker` on Linux/macOS, `%AppData%\mtproto-checker` on Windows), created with `0700` and files with `0600` (owner-only).
- **Nothing sensitive is committed.** These paths live entirely outside the repo, and `.gitignore` additionally blocks `session.json`, `app.json`, `*.session`, and the built binary as a safety net. The history was audited — no phone numbers, emails, real `api_hash`, or session data appear in any commit.
- **No third-party servers, telemetry, or analytics.** The only outbound traffic is to Telegram's own API (for login/fetching, through the user's chosen MTProto proxy) and direct TCP to the proxies being tested. No data is sent anywhere else.
- The only hardcoded credentials are Telegram's well-known **public test** `api_id`/`api_hash` (used as a fallback), not anyone's personal keys.

## Testing
- `go vet ./...`, `go test ./...` — green (parser unit tests cover real channel samples: URL junk-trimming, labeled/unicode formats, inline buttons, webpage previews, dedup, and junk-port filtering).
- Cross-compiles cleanly for **Windows** (`GOOS=windows GOARCH=amd64`/`arm64`), Linux, and macOS — pure Go, no CGO.

## Notes / limitations
- Fetching requires a one-time Telegram login and a working MTProto proxy link (an MTProto proxy can only tunnel Telegram's own protocol, not arbitrary HTTP — hence the removal of the web-scrape path).
- A channel that simply reposts a small pool will legitimately yield fewer unique proxies than requested; the per-channel diagnostic line makes this visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
